### PR TITLE
[codex] Fix Codex Desktop live connection PATH

### DIFF
--- a/Sources/VibelslandFree/CodexDesktopLiveClient.swift
+++ b/Sources/VibelslandFree/CodexDesktopLiveClient.swift
@@ -47,12 +47,7 @@ final class CodexDesktopLiveClient: @unchecked Sendable {
     }
 
     private func findCodexExecutable() -> String? {
-        let candidates = [
-            "/opt/homebrew/bin/codex",
-            "/usr/local/bin/codex",
-            "/Applications/Codex.app/Contents/Resources/codex"
-        ]
-        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+        CodexExecutableResolver.executablePath()
     }
 
     private func runProbe(codexPath: String, timeout: TimeInterval) throws -> String {
@@ -81,6 +76,7 @@ final class CodexDesktopLiveClient: @unchecked Sendable {
 
         process.executableURL = URL(fileURLWithPath: codexPath)
         process.arguments = ["app-server", "--listen", "stdio://"]
+        process.environment = CodexExecutableResolver.processEnvironment(forExecutablePath: codexPath)
         process.standardInput = stdin
         process.standardOutput = stdout
         process.standardError = stderr

--- a/Sources/VibelslandFree/SessionStore.swift
+++ b/Sources/VibelslandFree/SessionStore.swift
@@ -173,6 +173,11 @@ final class SessionStore: ObservableObject {
         }
     }
 
+    func repairConnections() {
+        installSelectedHooks()
+        refreshDiagnostics()
+    }
+
     func uninstallHooks() {
         do {
             let report = try hookInstaller.uninstallHooks()
@@ -188,6 +193,9 @@ final class SessionStore: ObservableObject {
 
     func refreshDiagnostics() {
         refreshHealthChecks()
+        if configurationStore.config.enableCodexDesktop {
+            codexAppServerLiveClient.retryNow()
+        }
         Task {
             await refreshCodexConnectivity()
             await refreshCodexDesktop(force: true)
@@ -1233,7 +1241,7 @@ final class SessionStore: ObservableObject {
                 name: "Codex Desktop",
                 status: configurationStore.config.enableCodexDesktop ? (codexDesktopApprovalConnected ? .normal : .needsAction) : .disabled,
                 detail: configurationStore.config.enableCodexDesktop ? codexDesktopDetail : "来源已关闭，不读取 Codex Desktop 状态",
-                suggestedAction: configurationStore.config.enableCodexDesktop ? "重新检测" : "在接收来源中启用"
+                suggestedAction: configurationStore.config.enableCodexDesktop ? "重新连接" : "在接收来源中启用"
             )
         ]
     }

--- a/Sources/VibelslandFree/SettingsView.swift
+++ b/Sources/VibelslandFree/SettingsView.swift
@@ -16,7 +16,7 @@ struct SettingsView: View {
                         error: store.lastError,
                         items: store.exceptionOnlyHealthChecks,
                         refresh: store.refreshDiagnostics,
-                        repairHooks: store.installSelectedHooks,
+                        repairConnections: store.repairConnections,
                         openLogs: store.openLogs
                     )
                 }
@@ -49,7 +49,7 @@ struct SettingsView: View {
                 MaintenanceSection(
                     allHealthChecks: store.healthChecks,
                     refresh: store.refreshDiagnostics,
-                    repairHooks: store.installSelectedHooks,
+                    repairConnections: store.repairConnections,
                     openLogs: store.openLogs
                 )
 
@@ -154,7 +154,7 @@ private struct IssueSummarySection: View {
     let error: String?
     let items: [HealthCheckItem]
     let refresh: () -> Void
-    let repairHooks: () -> Void
+    let repairConnections: () -> Void
     let openLogs: () -> Void
 
     var body: some View {
@@ -175,9 +175,9 @@ private struct IssueSummarySection: View {
                     Button("重新检测", action: refresh)
                         .accessibilityLabel("重新检测")
                         .accessibilityIdentifier("settings.issue.refresh")
-                    Button("修复 Hooks", action: repairHooks)
+                    Button("修复接入", action: repairConnections)
                         .buttonStyle(.borderedProminent)
-                        .accessibilityLabel("修复 Hooks")
+                        .accessibilityLabel("修复接入")
                         .accessibilityIdentifier("settings.issue.repairHooks")
                 }
 
@@ -395,7 +395,7 @@ private struct ApprovalPreferencesSection: View {
 private struct MaintenanceSection: View {
     let allHealthChecks: [HealthCheckItem]
     let refresh: () -> Void
-    let repairHooks: () -> Void
+    let repairConnections: () -> Void
     let openLogs: () -> Void
 
     var body: some View {
@@ -405,9 +405,9 @@ private struct MaintenanceSection: View {
                     Button("重新检测", action: refresh)
                         .accessibilityLabel("重新检测")
                         .accessibilityIdentifier("settings.maintenance.refresh")
-                    Button("安装/修复 Hooks", action: repairHooks)
+                    Button("修复接入", action: repairConnections)
                         .buttonStyle(.borderedProminent)
-                        .accessibilityLabel("安装/修复 Hooks")
+                        .accessibilityLabel("修复接入")
                         .accessibilityIdentifier("settings.maintenance.repairHooks")
                     Button("打开日志", action: openLogs)
                         .accessibilityLabel("打开日志")

--- a/Sources/VibelslandFreeCore/CodexAppServerLiveClient.swift
+++ b/Sources/VibelslandFreeCore/CodexAppServerLiveClient.swift
@@ -110,6 +110,15 @@ package final class CodexAppServerLiveClient: @unchecked Sendable {
         }
     }
 
+    package func retryNow() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.shouldRun = true
+            guard self.process == nil else { return }
+            self.startLocked()
+        }
+    }
+
     package func respond(
         to approval: CodexDesktopApproval,
         decision: ApprovalDecision,
@@ -243,6 +252,7 @@ package final class CodexAppServerLiveClient: @unchecked Sendable {
 
         process.executableURL = URL(fileURLWithPath: codexPath)
         process.arguments = ["app-server", "proxy", "--sock", socketURL.path]
+        process.environment = CodexExecutableResolver.processEnvironment(forExecutablePath: codexPath)
         process.standardInput = stdin
         process.standardOutput = stdout
         process.standardError = stderr
@@ -260,6 +270,9 @@ package final class CodexAppServerLiveClient: @unchecked Sendable {
             guard !data.isEmpty else { return }
             let detail = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             if !detail.isEmpty {
+                self?.queue.async { [weak self] in
+                    self?.lastFailureMessage = detail
+                }
                 self?.logger.error("codex.desktop.live.stderr", detail: detail)
             }
         }
@@ -323,7 +336,9 @@ package final class CodexAppServerLiveClient: @unchecked Sendable {
         stdoutBuffer.removeAll()
         failPendingThreadLoadedChecks()
         if shouldRun {
-            lastFailureMessage = "Codex Desktop 实时审批连接已断开"
+            if lastFailureMessage?.isEmpty != false {
+                lastFailureMessage = "Codex Desktop 实时审批连接已断开"
+            }
         }
         publishStatus(false, nil)
         scheduleReconnect()
@@ -465,17 +480,7 @@ package final class CodexAppServerLiveClient: @unchecked Sendable {
     }
 
     private func findCodexExecutable() -> String? {
-        if let override = ProcessInfo.processInfo.environment["VIBELSLAND_CODEX_EXECUTABLE"],
-           FileManager.default.isExecutableFile(atPath: override) {
-            return override
-        }
-
-        let candidates = [
-            "/opt/homebrew/bin/codex",
-            "/usr/local/bin/codex",
-            "/Applications/Codex.app/Contents/Resources/codex"
-        ]
-        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+        CodexExecutableResolver.executablePath()
     }
 }
 

--- a/Sources/VibelslandFreeCore/CodexExecutableResolver.swift
+++ b/Sources/VibelslandFreeCore/CodexExecutableResolver.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+package enum CodexExecutableResolver {
+    package static func executablePath(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> String? {
+        if let override = environment["VIBELSLAND_CODEX_EXECUTABLE"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !override.isEmpty,
+           fileManager.isExecutableFile(atPath: override) {
+            return override
+        }
+
+        return candidatePaths(environment: environment).first {
+            fileManager.isExecutableFile(atPath: $0)
+        }
+    }
+
+    package static func processEnvironment(
+        forExecutablePath executablePath: String,
+        baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> [String: String] {
+        var environment = baseEnvironment
+        var pathEntries: [String] = []
+        var seen = Set<String>()
+
+        func appendPath(_ path: String?) {
+            guard let path = path?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !path.isEmpty,
+                  seen.insert(path).inserted else {
+                return
+            }
+            pathEntries.append(path)
+        }
+
+        let executableURL = URL(fileURLWithPath: executablePath)
+        let executableDirectory = executableURL.deletingLastPathComponent().path
+        appendPath(executableDirectory)
+
+        if let destination = try? fileManager.destinationOfSymbolicLink(atPath: executablePath) {
+            let resolvedPath = destination.hasPrefix("/")
+                ? destination
+                : URL(fileURLWithPath: executableDirectory).appendingPathComponent(destination).standardizedFileURL.path
+            appendPath(URL(fileURLWithPath: resolvedPath).deletingLastPathComponent().path)
+        }
+
+        let homePath = homePath(environment: baseEnvironment)
+        appendPath(homePath.map { URL(fileURLWithPath: $0).appendingPathComponent(".local/bin").path })
+        appendPath(homePath.map { URL(fileURLWithPath: $0).appendingPathComponent(".codex/packages/standalone/current/bin").path })
+        appendPath("/Applications/Codex.app/Contents/Resources")
+        appendPath("/usr/local/bin")
+        appendPath("/opt/homebrew/bin")
+        appendPath("/usr/bin")
+        appendPath("/bin")
+        appendPath("/usr/sbin")
+        appendPath("/sbin")
+
+        if let existingPath = baseEnvironment["PATH"] {
+            for entry in existingPath.split(separator: ":") {
+                appendPath(String(entry))
+            }
+        }
+
+        environment["PATH"] = pathEntries.joined(separator: ":")
+        return environment
+    }
+
+    package static func candidatePaths(environment: [String: String] = ProcessInfo.processInfo.environment) -> [String] {
+        let homePath = homePath(environment: environment)
+        var paths: [String] = []
+
+        if let homePath {
+            let homeURL = URL(fileURLWithPath: homePath, isDirectory: true)
+            paths.append(homeURL.appendingPathComponent(".local/bin/codex").path)
+            paths.append(homeURL.appendingPathComponent(".codex/packages/standalone/current/bin/codex").path)
+        }
+
+        paths.append(contentsOf: [
+            "/opt/homebrew/bin/codex",
+            "/usr/local/bin/codex",
+            "/Applications/Codex.app/Contents/Resources/codex"
+        ])
+
+        return paths
+    }
+
+    private static func homePath(environment: [String: String]) -> String? {
+        if let home = environment["HOME"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !home.isEmpty {
+            return home
+        }
+        return FileManager.default.homeDirectoryForCurrentUser.path
+    }
+}

--- a/Tests/VibelslandFreeCoreTests/VibelslandFreeCoreTests.swift
+++ b/Tests/VibelslandFreeCoreTests/VibelslandFreeCoreTests.swift
@@ -396,7 +396,40 @@ struct VibelslandFreeCoreTests {
         let disabledFeatureFlag = CodexConfigMerger.mergedFeatureFlagConfig(existing: "[features]\ncodex_hooks = false\n")
         XCTAssertTrue(disabledFeatureFlag.changed && disabledFeatureFlag.text.contains("codex_hooks = true"), "Codex feature flag flips false")
         XCTAssertTrue(DisplayTextSanitizer.sanitize("复刻 " + "Vibe " + "Island UI") == "复刻 浮岛 UI", "Display title sanitizer")
-        
+
+        let resolverHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vibelsland-codex-resolver-\(UUID().uuidString)", isDirectory: true)
+        let standaloneBinURL = resolverHome
+            .appendingPathComponent(".codex/packages/standalone/current/bin", isDirectory: true)
+        let localBinURL = resolverHome
+            .appendingPathComponent(".local/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: standaloneBinURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: localBinURL, withIntermediateDirectories: true)
+        let standaloneCodexURL = standaloneBinURL.appendingPathComponent("codex")
+        let localCodexURL = localBinURL.appendingPathComponent("codex")
+        try "#!/bin/sh\n".write(to: standaloneCodexURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: standaloneCodexURL.path)
+        try FileManager.default.createSymbolicLink(at: localCodexURL, withDestinationURL: standaloneCodexURL)
+        defer { try? FileManager.default.removeItem(at: resolverHome) }
+
+        XCTAssertEqual(
+            CodexExecutableResolver.executablePath(environment: ["HOME": resolverHome.path]),
+            localCodexURL.path,
+            "Codex executable resolver prefers the user-installed CLI before bundled app resources"
+        )
+        let codexEnvironment = CodexExecutableResolver.processEnvironment(
+            forExecutablePath: localCodexURL.path,
+            baseEnvironment: ["HOME": resolverHome.path, "PATH": "/custom/bin"]
+        )
+        let pathEntries = codexEnvironment["PATH"]?.split(separator: ":").map(String.init) ?? []
+        XCTAssertEqual(pathEntries.first, localBinURL.path, "Codex child PATH starts with the selected executable directory")
+        XCTAssertTrue(pathEntries.contains(standaloneBinURL.path), "Codex child PATH includes symlink target directory")
+        XCTAssertTrue(pathEntries.contains("/Applications/Codex.app/Contents/Resources"), "Codex child PATH includes bundled Codex resources")
+        XCTAssertTrue(
+            (pathEntries.firstIndex(of: standaloneBinURL.path) ?? .max) < (pathEntries.firstIndex(of: "/custom/bin") ?? .min),
+            "Codex child PATH puts known runtime locations before inherited PATH entries"
+        )
+
         let desktopCommandRequest: [String: Any] = [
             "id": "request-1",
             "method": "item/commandExecution/requestApproval",


### PR DESCRIPTION
## Summary

Fixes the Codex Desktop real-time approval connection failing from the macOS app environment when the Codex proxy process cannot find `node`.

## Root Cause

The settings warning was surfaced as a Codex Desktop live approval disconnect, but the actual app log showed the proxy child process exiting with `env: node: No such file or directory`. Finder-launched macOS apps do not inherit the same shell `PATH`, and the app was also resolving Codex through a narrow hard-coded candidate list.

## Changes

- Add a shared Codex executable resolver that prefers the user-installed Codex CLI and builds a stable child-process `PATH`.
- Apply that resolver to both Codex app-server probing and Codex Desktop live proxy startup.
- Make the settings repair action repair the whole local connection path instead of only reinstalling hooks.
- Preserve proxy stderr as the last live connection failure detail.
- Add regression coverage for executable resolution and child `PATH` construction.

## Validation

- `zsh scripts/run-tests.sh`
- `zsh scripts/build-app.sh`
- Launched the rebuilt app locally and confirmed it starts the Codex app-server proxy without the previous repeating `env: node` error.