### PR TITLE
feat: bound app.log size and redact home paths in logs

### DIFF
--- a/Sources/VibelslandFreeCore/AppLogger.swift
+++ b/Sources/VibelslandFreeCore/AppLogger.swift
@@ -6,9 +6,17 @@ package final class AppLogger: @unchecked Sendable {
     private let queue = DispatchQueue(label: "free.vibelsland.logger")
     private let fileURL: URL
     private let formatter: ISO8601DateFormatter
+    private let homePath: String
+    private let maxLogBytes: Int
 
-    init(fileURL: URL = AppPaths.logURL) {
+    init(
+        fileURL: URL = AppPaths.logURL,
+        homePath: String = AppPaths.home.path,
+        maxLogBytes: Int = 5 * 1024 * 1024
+    ) {
         self.fileURL = fileURL
+        self.homePath = homePath
+        self.maxLogBytes = maxLogBytes
         formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
     }
@@ -21,24 +29,64 @@ package final class AppLogger: @unchecked Sendable {
         write(level: "error", event: event, detail: detail)
     }
 
+    /// Blocks until every previously enqueued write has been flushed to disk.
+    /// Intended for tests and shutdown; production logging stays asynchronous.
+    package func flush() {
+        queue.sync {}
+    }
+
+    /// Replaces the user's home directory prefix with `~` so that shared logs do
+    /// not leak the macOS account name or absolute private project paths.
+    /// The prefix is only collapsed at a path boundary, so `/Users/ann` never
+    /// corrupts a longer sibling path such as `/Users/annette`.
+    package static func redactHome(_ text: String, home: String) -> String {
+        guard !home.isEmpty, text.contains(home) else { return text }
+        let escaped = NSRegularExpression.escapedPattern(for: home)
+        let pattern = escaped + "(?=/|$|[\\s\"':,);\\]])"
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return text.replacingOccurrences(of: home + "/", with: "~/")
+        }
+        let range = NSRange(text.startIndex..., in: text)
+        return regex.stringByReplacingMatches(in: text, range: range, withTemplate: "~")
+    }
+
     private func write(level: String, event: String, detail: String) {
-        let line = "\(formatter.string(from: Date())) [\(level)] \(event) \(detail)\n"
+        let redactedDetail = Self.redactHome(detail, home: homePath)
+        let line = "\(formatter.string(from: Date())) [\(level)] \(event) \(redactedDetail)\n"
         queue.async {
             do {
                 try AppPaths.ensureRuntimeDirectories()
-                if FileManager.default.fileExists(atPath: self.fileURL.path) {
-                    let handle = try FileHandle(forWritingTo: self.fileURL)
-                    try handle.seekToEnd()
-                    if let data = line.data(using: .utf8) {
-                        try handle.write(contentsOf: data)
-                    }
-                    try handle.close()
-                } else {
-                    try line.write(to: self.fileURL, atomically: true, encoding: .utf8)
-                }
+                self.rotateIfNeeded()
+                try self.append(line)
             } catch {
                 NSLog("VibelslandFree log failed: \(error.localizedDescription)")
             }
+        }
+    }
+
+    /// When the active log reaches the size cap, move it aside to a single `.1`
+    /// backup. Disk use therefore stays bounded at roughly twice the cap.
+    private func rotateIfNeeded() {
+        let manager = FileManager.default
+        guard let attributes = try? manager.attributesOfItem(atPath: fileURL.path),
+              let size = (attributes[.size] as? NSNumber)?.intValue,
+              size >= maxLogBytes else {
+            return
+        }
+        let rotatedURL = fileURL.appendingPathExtension("1")
+        try? manager.removeItem(at: rotatedURL)
+        try? manager.moveItem(at: fileURL, to: rotatedURL)
+    }
+
+    private func append(_ line: String) throws {
+        guard let data = line.data(using: .utf8) else { return }
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            let handle = try FileHandle(forWritingTo: fileURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+        } else {
+            try line.write(to: fileURL, atomically: true, encoding: .utf8)
         }
     }
 }

--- a/Tests/VibelslandFreeCoreTests/AppLoggerTests.swift
+++ b/Tests/VibelslandFreeCoreTests/AppLoggerTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import VibelslandFreeCore
+
+@Suite
+struct AppLoggerTests {
+    @Test func testRedactHomeCollapsesPrefixAtPathBoundaries() {
+        let home = "/Users/ann"
+        XCTAssertEqual(
+            AppLogger.redactHome("/Users/ann/.claude/settings.json", home: home),
+            "~/.claude/settings.json"
+        )
+        // Path embedded in a larger message with a trailing space.
+        XCTAssertEqual(
+            AppLogger.redactHome("open /Users/ann/code/proj failed", home: home),
+            "open ~/code/proj failed"
+        )
+        // Path that ends exactly at the home directory.
+        XCTAssertEqual(AppLogger.redactHome("cwd=/Users/ann", home: home), "cwd=~")
+        // Multiple occurrences are all collapsed.
+        XCTAssertEqual(
+            AppLogger.redactHome("/Users/ann/a -> /Users/ann/b", home: home),
+            "~/a -> ~/b"
+        )
+    }
+
+    @Test func testRedactHomeDoesNotCorruptSimilarSiblingPaths() {
+        let home = "/Users/ann"
+        // A longer account name must stay intact (no boundary after `ann`).
+        XCTAssertEqual(
+            AppLogger.redactHome("/Users/annette/secret", home: home),
+            "/Users/annette/secret"
+        )
+    }
+
+    @Test func testRedactHomeIsNoOpWhenAbsentOrHomeEmpty() {
+        XCTAssertEqual(AppLogger.redactHome("no path here", home: "/Users/ann"), "no path here")
+        XCTAssertEqual(AppLogger.redactHome("/Users/ann/x", home: ""), "/Users/ann/x")
+    }
+
+    @Test func testLogRotationBoundsSizeAndKeepsOneBackup() throws {
+        let manager = FileManager.default
+        let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("vibelsland-logger-\(UUID().uuidString)", isDirectory: true)
+        try manager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? manager.removeItem(at: tempDir) }
+
+        let logURL = tempDir.appendingPathComponent("app.log")
+        let cap = 512
+        let logger = AppLogger(fileURL: logURL, homePath: "/Users/ann", maxLogBytes: cap)
+
+        for index in 0..<300 {
+            logger.info("event.\(index)", detail: "/Users/ann/path/component/\(index)")
+        }
+        logger.flush()
+
+        // Rotation must have produced exactly one backup file.
+        let rotatedURL = logURL.appendingPathExtension("1")
+        XCTAssertTrue(manager.fileExists(atPath: rotatedURL.path))
+
+        // The active log stays bounded near the cap (cap + at most one line).
+        let activeSize = ((try? manager.attributesOfItem(atPath: logURL.path))?[.size] as? NSNumber)?.intValue ?? 0
+        XCTAssertTrue(activeSize < cap * 2)
+
+        // Home paths are redacted in the persisted log content.
+        let content = (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
+        XCTAssertFalse(content.contains("/Users/ann"))
+        XCTAssertTrue(content.contains("~/path/component"))
+    }
+}


### PR DESCRIPTION
## 改动
- **日志轮转**：`app.log` 达 5MB 时移到单个 `.1` 备份，磁盘占用封顶约 2× 上限，不再无限增长。
- **Home 路径脱敏**：写入层把 `/Users/<用户名>` 折叠为 `~`，带路径边界保护（不误伤 `/Users/annette` 这类更长的兄弟路径）。

## 动机
常驻菜单栏应用的日志会无限增长；日志 `detail` 含绝对路径（用户名 / 私有项目路径），用户分享日志排障时有泄露风险。`PRIVACY.md` 此前已诚实披露这两点（无自动清理、含本地路径），本 PR 落实修复。

## 测试
- 新增 `AppLoggerTests`：脱敏边界、轮转有界、落盘内容已脱敏。
- 本地仅 CommandLineTools（无完整 Xcode，runner 跑不了断言），已用 `swift build --build-tests` 编译验证 + 独立 Swift 进程真实运行逻辑 **11/11 通过**；断言执行交由 CI（`VIBELSLAND_REQUIRE_TEST_EXECUTION=1`）。

## 影响面
仅改 `AppLogger`，公共接口（`info`/`error`/`shared`）不变，13 处调用方零改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
