### PR TITLE
feat: add optional global hotkeys for island toggle and approval jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 
+- Added optional global hotkeys: ⌃⌥I toggles the island and ⌃⌥A jumps to the pending approval (off by default, no extra permissions required).
 - Added Japanese README and Japanese documentation pages.
 - Added GitHub Actions checks for Swift build and test-target discovery.
 - Added maintainer release gate improvements and clearer ad-hoc signing documentation.

--- a/Sources/VibelslandFree/AppDelegate.swift
+++ b/Sources/VibelslandFree/AppDelegate.swift
@@ -12,6 +12,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject, NSWi
     private var launchIntroWindow: LaunchIntroWindow?
     private var settingsWindow: NSWindow?
     private var statusItem: NSStatusItem?
+    private let hotKeyCenter = GlobalHotKeyCenter()
     private var configCancellable: AnyCancellable?
     private var runtimeObservers: [NSObjectProtocol] = []
     private var verificationObservers: [NSObjectProtocol] = []
@@ -44,10 +45,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject, NSWi
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.refreshLocalizedChrome()
+                self?.applyGlobalHotKeys()
             }
+        hotKeyCenter.onAction = { [weak self] action in
+            self?.perform(hotKeyAction: action)
+        }
+        applyGlobalHotKeys()
         installVerificationActionsIfNeeded()
         showIsland(launchAnimated: true)
         store.start()
+    }
+
+    private func applyGlobalHotKeys() {
+        hotKeyCenter.apply(
+            actions: GlobalHotKeyPolicy.actions(enabled: configurationStore.config.enableGlobalHotKeys)
+        )
+    }
+
+    private func perform(hotKeyAction action: GlobalHotKeyAction) {
+        switch action {
+        case .toggleIsland:
+            if store.isExpanded {
+                store.isExpanded = false
+            } else {
+                openIslandPanel()
+            }
+        case .jumpToApproval:
+            if let targetID = GlobalHotKeyPolicy.approvalTargetSessionID(in: store.sessions) {
+                store.selectedSessionID = targetID
+            }
+            openIslandPanel()
+        }
     }
 
     private func handOffToExistingInstanceIfNeeded() -> Bool {
@@ -136,6 +164,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject, NSWi
                 self?.setExpandedFromVerificationValue(rawExpanded)
             }
         })
+        verificationObservers.append(center.addObserver(
+            forName: .vibelslandVerifyHotKeyAction,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let rawAction = notification.userInfo?["action"] as? String
+            Task { @MainActor [weak self] in
+                self?.performHotKeyActionFromVerificationValue(rawAction)
+            }
+        })
+    }
+
+    private func performHotKeyActionFromVerificationValue(_ rawAction: String?) {
+        guard let rawAction,
+              let action = GlobalHotKeyAction(rawValue: rawAction) else {
+            store.lastError = "验证动作无效：无法识别快捷键动作"
+            return
+        }
+        perform(hotKeyAction: action)
     }
 
     private func resolveApprovalFromVerificationDecision(_ rawDecision: String?) {
@@ -367,4 +414,5 @@ extension Notification.Name {
     static let vibelslandVerifyResolveApproval = Notification.Name("free.vibelsland.verify.resolveApproval")
     static let vibelslandVerifyRestart = Notification.Name("free.vibelsland.verify.restart")
     static let vibelslandVerifySetExpanded = Notification.Name("free.vibelsland.verify.setExpanded")
+    static let vibelslandVerifyHotKeyAction = Notification.Name("free.vibelsland.verify.hotKeyAction")
 }

--- a/Sources/VibelslandFree/GlobalHotKeyCenter.swift
+++ b/Sources/VibelslandFree/GlobalHotKeyCenter.swift
@@ -1,0 +1,100 @@
+import AppKit
+import Carbon.HIToolbox
+import VibelslandFreeCore
+
+/// 用 Carbon RegisterEventHotKey 注册全局快捷键。
+/// 选 Carbon 而不是 NSEvent 全局监听：无需辅助功能权限、可吞掉按键事件、零第三方依赖。
+@MainActor
+final class GlobalHotKeyCenter {
+    var onAction: ((GlobalHotKeyAction) -> Void)?
+
+    private var registeredHotKeys: [EventHotKeyRef] = []
+    private var eventHandler: EventHandlerRef?
+    private let logger: AppLogger
+
+    private static let signature: OSType = 0x5642_4652 // "VBFR"
+
+    init(logger: AppLogger = .shared) {
+        self.logger = logger
+    }
+
+    func apply(actions: [GlobalHotKeyAction]) {
+        unregisterAll()
+        guard !actions.isEmpty else { return }
+        installEventHandlerIfNeeded()
+        for action in actions {
+            var hotKeyRef: EventHotKeyRef?
+            let hotKeyID = EventHotKeyID(signature: Self.signature, id: action.carbonHotKeyID)
+            let status = RegisterEventHotKey(
+                action.keyCode,
+                action.carbonModifiers,
+                hotKeyID,
+                GetEventDispatcherTarget(),
+                0,
+                &hotKeyRef
+            )
+            if status == noErr, let hotKeyRef {
+                registeredHotKeys.append(hotKeyRef)
+                logger.info("hotkey.registered", detail: "\(action.rawValue) \(action.displayShortcut)")
+            } else {
+                logger.error("hotkey.register.failed", detail: "\(action.rawValue) status=\(status)")
+            }
+        }
+    }
+
+    private func unregisterAll() {
+        for hotKeyRef in registeredHotKeys {
+            UnregisterEventHotKey(hotKeyRef)
+        }
+        registeredHotKeys.removeAll()
+    }
+
+    private func installEventHandlerIfNeeded() {
+        guard eventHandler == nil else { return }
+        var eventType = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed)
+        )
+        let status = InstallEventHandler(
+            GetEventDispatcherTarget(),
+            { _, event, userData in
+                guard let event, let userData else { return OSStatus(eventNotHandledErr) }
+                var hotKeyID = EventHotKeyID()
+                let status = GetEventParameter(
+                    event,
+                    EventParamName(kEventParamDirectObject),
+                    EventParamType(typeEventHotKeyID),
+                    nil,
+                    MemoryLayout<EventHotKeyID>.size,
+                    nil,
+                    &hotKeyID
+                )
+                guard status == noErr, hotKeyID.signature == GlobalHotKeyCenter.signature else {
+                    return OSStatus(eventNotHandledErr)
+                }
+                let center = Unmanaged<GlobalHotKeyCenter>.fromOpaque(userData).takeUnretainedValue()
+                // Carbon 热键事件由主线程事件分发器派发，这里断言回到 MainActor。
+                MainActor.assumeIsolated {
+                    center.handleHotKey(id: hotKeyID.id)
+                }
+                return noErr
+            },
+            1,
+            &eventType,
+            Unmanaged.passUnretained(self).toOpaque(),
+            &eventHandler
+        )
+        if status != noErr {
+            logger.error("hotkey.handler.install.failed", detail: "status=\(status)")
+        }
+    }
+
+    private func handleHotKey(id: UInt32) {
+        guard let action = GlobalHotKeyPolicy.action(forHotKeyID: id) else {
+            logger.info("hotkey.unknown", detail: "id=\(id)")
+            return
+        }
+        logger.info("hotkey.triggered", detail: action.rawValue)
+        onAction?(action)
+    }
+}

--- a/Sources/VibelslandFree/SettingsView.swift
+++ b/Sources/VibelslandFree/SettingsView.swift
@@ -39,6 +39,7 @@ struct SettingsView: View {
                     soundTheme: binding(\.soundTheme),
                     doNotDisturb: binding(\.doNotDisturb),
                     maxVisibleSessions: binding(\.maxVisibleSessions),
+                    globalHotKeysEnabled: binding(\.enableGlobalHotKeys),
                     playPreview: store.playSoundPreview,
                     playAllPreviews: store.playAllSoundPreviews
                 )
@@ -375,6 +376,7 @@ private struct IslandPreferencesSection: View {
     @Binding var soundTheme: SoundTheme
     @Binding var doNotDisturb: Bool
     @Binding var maxVisibleSessions: Int
+    @Binding var globalHotKeysEnabled: Bool
     let playPreview: (RetroSoundKind) -> Void
     let playAllPreviews: () -> Void
 
@@ -470,8 +472,29 @@ private struct IslandPreferencesSection: View {
                     }
                     .frame(width: 150)
                 }
+                SettingsDivider()
+                SettingsRow(icon: "keyboard", title: AppText.pick(configurationStore.config.language, english: "Global hotkeys", japanese: "グローバルショートカット", chinese: "全局快捷键")) {
+                    Toggle("", isOn: $globalHotKeysEnabled)
+                        .labelsHidden()
+                }
+                Text(globalHotKeysHint)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.bottom, 6)
             }
         }
+    }
+
+    private var globalHotKeysHint: String {
+        let toggle = GlobalHotKeyAction.toggleIsland.displayShortcut
+        let jump = GlobalHotKeyAction.jumpToApproval.displayShortcut
+        return AppText.pick(
+            configurationStore.config.language,
+            english: "\(toggle) expand/collapse island · \(jump) jump to pending approval",
+            japanese: "\(toggle) アイランドを展開/折りたたみ · \(jump) 承認待ちへ移動",
+            chinese: "\(toggle) 展开/收起浮岛 · \(jump) 跳转待审批"
+        )
     }
 }
 

--- a/Sources/VibelslandFreeCore/AppConfiguration.swift
+++ b/Sources/VibelslandFreeCore/AppConfiguration.swift
@@ -47,6 +47,7 @@ package struct AppConfiguration: Codable, Equatable {
     package var language: AppLanguage
     package var approvalTimeoutSeconds: TimeInterval
     package var maxVisibleSessions: Int
+    package var enableGlobalHotKeys: Bool
 
     package static let `default` = AppConfiguration(
         enableClaude: true,
@@ -59,7 +60,8 @@ package struct AppConfiguration: Codable, Equatable {
         islandPosition: .topCenter,
         language: .english,
         approvalTimeoutSeconds: 7_200,
-        maxVisibleSessions: 5
+        maxVisibleSessions: 5,
+        enableGlobalHotKeys: false
     )
 
     package enum CodingKeys: String, CodingKey {
@@ -74,6 +76,7 @@ package struct AppConfiguration: Codable, Equatable {
         case language
         case approvalTimeoutSeconds
         case maxVisibleSessions
+        case enableGlobalHotKeys
     }
 
     package init(
@@ -87,7 +90,8 @@ package struct AppConfiguration: Codable, Equatable {
         islandPosition: IslandPosition,
         language: AppLanguage,
         approvalTimeoutSeconds: TimeInterval,
-        maxVisibleSessions: Int
+        maxVisibleSessions: Int,
+        enableGlobalHotKeys: Bool = false
     ) {
         self.enableClaude = enableClaude
         self.enableCodexCLI = enableCodexCLI
@@ -100,6 +104,7 @@ package struct AppConfiguration: Codable, Equatable {
         self.language = language
         self.approvalTimeoutSeconds = approvalTimeoutSeconds
         self.maxVisibleSessions = maxVisibleSessions
+        self.enableGlobalHotKeys = enableGlobalHotKeys
     }
 
     package init(from decoder: Decoder) throws {
@@ -115,6 +120,7 @@ package struct AppConfiguration: Codable, Equatable {
         language = try container.decodeIfPresent(AppLanguage.self, forKey: .language) ?? Self.default.language
         approvalTimeoutSeconds = try container.decodeIfPresent(TimeInterval.self, forKey: .approvalTimeoutSeconds) ?? Self.default.approvalTimeoutSeconds
         maxVisibleSessions = try container.decodeIfPresent(Int.self, forKey: .maxVisibleSessions) ?? Self.default.maxVisibleSessions
+        enableGlobalHotKeys = try container.decodeIfPresent(Bool.self, forKey: .enableGlobalHotKeys) ?? Self.default.enableGlobalHotKeys
     }
 }
 

--- a/Sources/VibelslandFreeCore/GlobalHotKeyPolicy.swift
+++ b/Sources/VibelslandFreeCore/GlobalHotKeyPolicy.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+package enum GlobalHotKeyAction: String, Codable, CaseIterable, Identifiable {
+    case toggleIsland
+    case jumpToApproval
+
+    package var id: String { rawValue }
+
+    /// Carbon RegisterEventHotKey 使用的稳定 ID，注册与回调之间靠它对应。
+    package var carbonHotKeyID: UInt32 {
+        switch self {
+        case .toggleIsland: 1
+        case .jumpToApproval: 2
+        }
+    }
+
+    /// Carbon 虚拟键码（kVK_ANSI_*）。
+    package var keyCode: UInt32 {
+        switch self {
+        case .toggleIsland: 34 // kVK_ANSI_I
+        case .jumpToApproval: 0 // kVK_ANSI_A
+        }
+    }
+
+    /// Carbon 修饰键掩码：controlKey(0x1000) + optionKey(0x0800)。
+    /// 选 ⌃⌥ 组合是因为它极少与系统或常见应用快捷键冲突。
+    package var carbonModifiers: UInt32 {
+        0x1000 | 0x0800
+    }
+
+    package var displayShortcut: String {
+        switch self {
+        case .toggleIsland: "⌃⌥I"
+        case .jumpToApproval: "⌃⌥A"
+        }
+    }
+}
+
+package enum GlobalHotKeyPolicy {
+    package static func actions(enabled: Bool) -> [GlobalHotKeyAction] {
+        enabled ? GlobalHotKeyAction.allCases : []
+    }
+
+    package static func action(forHotKeyID id: UInt32) -> GlobalHotKeyAction? {
+        GlobalHotKeyAction.allCases.first { $0.carbonHotKeyID == id }
+    }
+
+    /// 跳转目标：最早发起且仍未过期的审批所在会话。
+    package static func approvalTargetSessionID(in sessions: [AgentSession]) -> AgentSession.ID? {
+        sessions
+            .filter { session in
+                guard let approval = session.approval else { return false }
+                return !approval.isExpired
+            }
+            .min { lhs, rhs in
+                (lhs.approval?.createdAt ?? .distantFuture) < (rhs.approval?.createdAt ?? .distantFuture)
+            }?
+            .id
+    }
+}

--- a/Tests/VibelslandFreeCoreTests/GlobalHotKeyPolicyTests.swift
+++ b/Tests/VibelslandFreeCoreTests/GlobalHotKeyPolicyTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+@testable import VibelslandFreeCore
+
+@Suite
+struct GlobalHotKeyPolicyTests {
+    @Test func testActionsFollowEnabledSwitch() {
+        XCTAssertEqual(GlobalHotKeyPolicy.actions(enabled: false).count, 0, "Disabled hotkeys register nothing")
+        XCTAssertEqual(
+            GlobalHotKeyPolicy.actions(enabled: true),
+            GlobalHotKeyAction.allCases,
+            "Enabled hotkeys register every action"
+        )
+    }
+
+    @Test func testHotKeyIdentifiersAndCombosAreUnique() {
+        let ids = GlobalHotKeyAction.allCases.map(\.carbonHotKeyID)
+        XCTAssertEqual(Set(ids).count, ids.count, "Carbon hotkey IDs must be unique")
+
+        let combos = GlobalHotKeyAction.allCases.map { "\($0.keyCode)-\($0.carbonModifiers)" }
+        XCTAssertEqual(Set(combos).count, combos.count, "Key combos must not collide")
+    }
+
+    @Test func testActionLookupRoundTrip() {
+        for action in GlobalHotKeyAction.allCases {
+            XCTAssertEqual(
+                GlobalHotKeyPolicy.action(forHotKeyID: action.carbonHotKeyID),
+                action,
+                "Registered ID resolves back to its action"
+            )
+        }
+        XCTAssertTrue(
+            GlobalHotKeyPolicy.action(forHotKeyID: 9_999) == nil,
+            "Unknown hotkey ID resolves to nil"
+        )
+    }
+
+    @Test func testCarbonModifiersUseControlOption() {
+        for action in GlobalHotKeyAction.allCases {
+            XCTAssertEqual(action.carbonModifiers, 0x1800, "Default combo is control+option")
+        }
+    }
+
+    @Test func testApprovalTargetPicksOldestUnexpiredApproval() {
+        let now = Date()
+        let sessions = [
+            hotKeySession(id: "no-approval", approval: nil),
+            hotKeySession(id: "newer", approval: approval(id: "a-newer", createdAt: now)),
+            hotKeySession(id: "older", approval: approval(id: "a-older", createdAt: now.addingTimeInterval(-120))),
+            hotKeySession(id: "expired", approval: approval(id: "a-expired", createdAt: now.addingTimeInterval(-600), expired: true))
+        ]
+        XCTAssertEqual(
+            GlobalHotKeyPolicy.approvalTargetSessionID(in: sessions),
+            "older",
+            "Jump target is the oldest unexpired approval"
+        )
+    }
+
+    @Test func testApprovalTargetIsNilWithoutPendingApprovals() {
+        let sessions = [
+            hotKeySession(id: "plain", approval: nil),
+            hotKeySession(id: "expired", approval: approval(id: "a-expired", createdAt: Date(), expired: true))
+        ]
+        XCTAssertTrue(
+            GlobalHotKeyPolicy.approvalTargetSessionID(in: sessions) == nil,
+            "No pending approval means no jump target"
+        )
+    }
+
+    @Test func testConfigurationDefaultsToDisabledAndDecodesLegacyConfig() throws {
+        XCTAssertFalse(AppConfiguration.default.enableGlobalHotKeys, "Hotkeys are opt-in")
+
+        let legacyConfig = """
+        {
+          "enableClaude": true,
+          "enableCodexCLI": true,
+          "enableCodexDesktop": true,
+          "enableSounds": true,
+          "soundTheme": "soft",
+          "doNotDisturb": false,
+          "launchAtLogin": false,
+          "islandPosition": "topCenter",
+          "approvalTimeoutSeconds": 7200,
+          "maxVisibleSessions": 5
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AppConfiguration.self, from: legacyConfig)
+        XCTAssertFalse(decoded.enableGlobalHotKeys, "Legacy configs without the key stay disabled")
+    }
+
+    private func approval(id: String, createdAt: Date, expired: Bool = false) -> ApprovalRequest {
+        ApprovalRequest(
+            id: id,
+            source: .claudeCode,
+            title: "Approval",
+            detail: "run command",
+            tool: "Bash",
+            workspace: "/tmp/vibelsland",
+            suggestedSessionAllow: false,
+            supportsCancel: false,
+            isExpired: expired,
+            createdAt: createdAt
+        )
+    }
+
+    private func hotKeySession(id: String, approval: ApprovalRequest?) -> AgentSession {
+        AgentSession(
+            id: id,
+            title: id,
+            prompt: id,
+            source: .claudeCode,
+            workspace: "/tmp/vibelsland",
+            terminal: "Claude Code",
+            updatedAt: Date(),
+            status: approval == nil ? .runningTool : .waitingApproval,
+            activity: [],
+            approval: approval,
+            question: nil,
+            subagents: [],
+            lastAssistantMessage: nil,
+            lastUserMessage: nil,
+            usage: nil
+        )
+    }
+}


### PR DESCRIPTION
## 概要

新增可选全局快捷键（默认关闭，设置页开关）：
- **⌃⌥I** 展开/收起浮岛
- **⌃⌥A** 跳转到等待最久的审批并展开面板

## 实现

- Carbon `RegisterEventHotKey`：零第三方依赖、无需辅助功能权限、按键不透传给其他应用。
- 注册/查找/跳转目标选取收敛在 `GlobalHotKeyPolicy`（Core 层可单测）。
- 新增验证动作 `vibelsland.verify.hotKeyAction` 供窗口自动化脚本使用。

## 验证

- `swift build` + 测试目标编译通过；策略断言在独立 Swift 进程全部通过（10 项）。
- 配置向后兼容：旧 config.json 解码后默认关闭。

## 合并顺序

堆叠 PR 链第 **1/6** 个：hotkeys → notifications → queue → update-check → claude-usage → adaptive-timers。本 PR 先合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)