### PR TITLE
feat: add optional macOS notifications for approval requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 
+- Added optional approval notifications: macOS Notification Center banners with Allow/Decline actions as a fallback when you are away from the island (off by default, withdrawn once the approval resolves, suppressed by Do Not Disturb).
 - Added optional global hotkeys: ⌃⌥I toggles the island and ⌃⌥A jumps to the pending approval (off by default, no extra permissions required).
 - Added Japanese README and Japanese documentation pages.
 - Added GitHub Actions checks for Swift build and test-target discovery.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -26,6 +26,8 @@ The app writes:
 
 Hook payloads are filtered before they are sent to the app. The bridge keeps only known metadata fields such as session ids, event type, workspace, transcript path, approval id, and selected tool information. Nested tool input is limited to small descriptive fields such as command, path, pattern, URL, and tool name.
 
+When the optional approval notification setting is enabled, the app posts approval summaries (source, tool, and truncated command detail) to macOS Notification Center with Allow/Decline actions. These notifications never leave the Mac, are withdrawn when the approval resolves, and follow the user's macOS notification and lock screen settings. The setting is off by default.
+
 Logs are intentionally conservative. They record connection state, event types, timestamps, local paths, thread/request ids, and error reasons, but do not intentionally store full transcript text or full sensitive command output.
 
 Logs stay on the user's Mac until the user deletes them. The app does not currently claim automatic log upload, automatic retention limits, or automatic log cleanup.

--- a/Sources/VibelslandFree/ApprovalNotificationCenter.swift
+++ b/Sources/VibelslandFree/ApprovalNotificationCenter.swift
@@ -1,0 +1,150 @@
+import Foundation
+import UserNotifications
+import VibelslandFreeCore
+
+/// UNUserNotificationCenter 的薄封装：发/撤审批通知，把通知动作路由回审批决定。
+/// 标识符编码与触发条件在 ApprovalNotificationPolicy（可单测），这里只做框架调用。
+@MainActor
+final class ApprovalNotificationCenter: NSObject {
+    var onDecision: ((_ approvalID: String, _ decision: ApprovalDecision) -> Void)?
+    var onOpenApproval: ((_ approvalID: String) -> Void)?
+    /// 点击横幅时按 ID 找回审批请求，用于校验动作是否仍受支持。
+    var approvalProvider: ((_ approvalID: String) -> ApprovalRequest?)?
+
+    private let logger: AppLogger
+    private var isActivated = false
+    private(set) var authorizationDenied = false
+
+    /// swift build 直接跑的裸可执行没有 bundle，UNUserNotificationCenter.current() 会抛
+    /// Objective-C 异常且 Swift 无法捕获，所以先按 bundle 存在与否降级。
+    nonisolated static var isSupportedProcess: Bool {
+        Bundle.main.bundleIdentifier != nil
+    }
+
+    init(logger: AppLogger = .shared) {
+        self.logger = logger
+        super.init()
+    }
+
+    func activate(language: AppLanguage) {
+        guard Self.isSupportedProcess else {
+            logger.info("notification.unsupported", detail: "no bundle identifier")
+            return
+        }
+        let center = UNUserNotificationCenter.current()
+        center.delegate = self
+        registerCategory(language: language)
+        guard !isActivated else { return }
+        isActivated = true
+        center.requestAuthorization(options: [.alert, .sound]) { [weak self] granted, error in
+            Task { @MainActor [weak self] in
+                self?.authorizationDenied = !granted
+                if let error {
+                    self?.logger.error("notification.authorization.failed", detail: error.localizedDescription)
+                } else {
+                    self?.logger.info("notification.authorization", detail: granted ? "granted" : "denied")
+                }
+            }
+        }
+    }
+
+    func registerCategory(language: AppLanguage) {
+        guard Self.isSupportedProcess else { return }
+        let accept = UNNotificationAction(
+            identifier: ApprovalNotificationPolicy.acceptActionIdentifier,
+            title: ApprovalDecision.accept.title(language: language),
+            options: []
+        )
+        let decline = UNNotificationAction(
+            identifier: ApprovalNotificationPolicy.declineActionIdentifier,
+            title: ApprovalDecision.decline.title(language: language),
+            options: [.destructive]
+        )
+        let category = UNNotificationCategory(
+            identifier: ApprovalNotificationPolicy.categoryIdentifier,
+            actions: [accept, decline],
+            intentIdentifiers: [],
+            options: []
+        )
+        UNUserNotificationCenter.current().setNotificationCategories([category])
+    }
+
+    func post(approval: ApprovalRequest, language: AppLanguage) {
+        guard Self.isSupportedProcess else { return }
+        let content = UNMutableNotificationContent()
+        content.title = AppText.pick(
+            language,
+            english: "\(approval.source.shortName) requests approval",
+            japanese: "\(approval.source.shortName) が承認を要求",
+            chinese: "\(approval.source.shortName) 请求审批"
+        )
+        content.body = ApprovalNotificationPolicy.body(for: approval)
+        content.categoryIdentifier = ApprovalNotificationPolicy.categoryIdentifier
+        // 浮岛已经播放审批提示音，这里不再叠加系统提示音。
+        let request = UNNotificationRequest(
+            identifier: ApprovalNotificationPolicy.notificationIdentifier(approvalID: approval.id),
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request) { [weak self] error in
+            guard let error else { return }
+            Task { @MainActor [weak self] in
+                self?.logger.error("notification.post.failed", detail: error.localizedDescription)
+            }
+        }
+        logger.info("notification.posted", detail: approval.id)
+    }
+
+    func withdraw(approvalID: String) {
+        guard Self.isSupportedProcess else { return }
+        let identifier = ApprovalNotificationPolicy.notificationIdentifier(approvalID: approvalID)
+        let center = UNUserNotificationCenter.current()
+        center.removePendingNotificationRequests(withIdentifiers: [identifier])
+        center.removeDeliveredNotifications(withIdentifiers: [identifier])
+    }
+}
+
+extension ApprovalNotificationCenter: UNUserNotificationCenterDelegate {
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .list])
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let requestIdentifier = response.notification.request.identifier
+        let actionIdentifier = response.actionIdentifier
+        // 决定动作只改本地状态，不需要让系统等待，这里直接完成回调。
+        completionHandler()
+        Task { @MainActor [weak self] in
+            self?.handleResponse(requestIdentifier: requestIdentifier, actionIdentifier: actionIdentifier)
+        }
+    }
+
+    private func handleResponse(requestIdentifier: String, actionIdentifier: String) {
+        guard let approvalID = ApprovalNotificationPolicy.approvalID(fromNotificationIdentifier: requestIdentifier) else {
+            return
+        }
+        if actionIdentifier == UNNotificationDefaultActionIdentifier {
+            onOpenApproval?(approvalID)
+            return
+        }
+        guard actionIdentifier != UNNotificationDismissActionIdentifier else { return }
+        guard let approval = approvalProvider?(approvalID),
+              let decision = ApprovalNotificationPolicy.decision(
+                forActionIdentifier: actionIdentifier,
+                approval: approval
+              ) else {
+            logger.info("notification.action.ignored", detail: actionIdentifier)
+            onOpenApproval?(approvalID)
+            return
+        }
+        onDecision?(approvalID, decision)
+    }
+}

--- a/Sources/VibelslandFree/SessionStore+Approvals.swift
+++ b/Sources/VibelslandFree/SessionStore+Approvals.swift
@@ -109,6 +109,7 @@ extension SessionStore {
         logger.info("approval.resolved.marked", detail: id)
         pendingCodexDesktopApprovals.removeValue(forKey: id)
         pendingCodexDesktopDecisions.removeValue(forKey: id)
+        approvalNotificationCenter.withdraw(approvalID: id)
     }
 
     func markApprovalFailed(
@@ -127,6 +128,7 @@ extension SessionStore {
         if expired {
             pendingCodexDesktopApprovals.removeValue(forKey: id)
             pendingCodexDesktopDecisions.removeValue(forKey: id)
+            approvalNotificationCenter.withdraw(approvalID: id)
         }
     }
 
@@ -146,6 +148,7 @@ extension SessionStore {
         logger.info("approval.timedOut", detail: id)
         pendingCodexDesktopApprovals.removeValue(forKey: id)
         pendingCodexDesktopDecisions.removeValue(forKey: id)
+        approvalNotificationCenter.withdraw(approvalID: id)
     }
 
     func markCodexDesktopRequestResolved(_ requestKey: String) {
@@ -164,6 +167,7 @@ extension SessionStore {
         }
         pendingCodexDesktopApprovals.removeValue(forKey: approvalID)
         pendingCodexDesktopDecisions.removeValue(forKey: approvalID)
+        approvalNotificationCenter.withdraw(approvalID: approvalID)
         logger.info("codex.desktop.approval.resolved", detail: requestKey)
     }
 

--- a/Sources/VibelslandFree/SessionStore+Events.swift
+++ b/Sources/VibelslandFree/SessionStore+Events.swift
@@ -111,13 +111,14 @@ extension SessionStore {
 
         upsert(session)
 
-        if approval != nil {
+        if let approval {
             selectedSessionID = session.id
             if !configurationStore.config.doNotDisturb {
                 isExpanded = true
             }
             logger.info("approval.focused", detail: "expanded=\(isExpanded) doNotDisturb=\(configurationStore.config.doNotDisturb)")
             playSound(.approval, key: "approval:\(session.id)", minimumInterval: 1.0)
+            notifyApprovalIfNeeded(approval)
         } else {
             playEventSound(event: event, previous: previousSession, current: session)
         }
@@ -164,6 +165,7 @@ extension SessionStore {
             isExpanded = true
         }
         playSound(.approval, key: "approval:\(session.id)", minimumInterval: 1.0)
+        notifyApprovalIfNeeded(approval.approvalRequest)
         logger.info("approval.focused", detail: "expanded=\(isExpanded) doNotDisturb=\(configurationStore.config.doNotDisturb)")
         logger.info("codex.desktop.approval.received", detail: approval.method)
     }
@@ -352,6 +354,10 @@ extension SessionStore {
             codexAppServerLiveClient.stop()
             stopCodexDesktopRefreshTimer()
             codexDesktopApprovalConnected = false
+        }
+        if configurationStore.config.enableApprovalNotifications {
+            // 覆盖两种情况：开关刚打开（首次激活+请求授权）、语言切换（动作按钮标题跟随语言）。
+            approvalNotificationCenter.activate(language: configurationStore.config.language)
         }
         refreshHealthChecks()
     }

--- a/Sources/VibelslandFree/SessionStore.swift
+++ b/Sources/VibelslandFree/SessionStore.swift
@@ -34,6 +34,7 @@ final class SessionStore: ObservableObject {
     let codexLiveClient: CodexDesktopLiveClient
     let codexAppServerLiveClient: CodexAppServerLiveClient
     let transcriptReader: ConversationTranscriptReader
+    let approvalNotificationCenter = ApprovalNotificationCenter()
     let logger: AppLogger
     var pendingReplies: [String: (String?) -> Void] = [:]
     var pendingEvents: [String: AgentEvent] = [:]
@@ -129,6 +130,35 @@ final class SessionStore: ObservableObject {
             .sink { [weak self] _ in
                 self?.handleConfigurationChanged()
             }
+
+        approvalNotificationCenter.approvalProvider = { [weak self] approvalID in
+            self?.pendingApproval(withID: approvalID)
+        }
+        approvalNotificationCenter.onDecision = { [weak self] approvalID, decision in
+            guard let self, let approval = self.pendingApproval(withID: approvalID) else { return }
+            self.resolveApproval(approval, decision: decision)
+        }
+        approvalNotificationCenter.onOpenApproval = { [weak self] approvalID in
+            guard let self else { return }
+            if let session = self.sessions.first(where: { $0.approval?.id == approvalID }) {
+                self.selectedSessionID = session.id
+            }
+            NSApp.activate(ignoringOtherApps: true)
+            self.isExpanded = true
+        }
+    }
+
+    func pendingApproval(withID id: String) -> ApprovalRequest? {
+        sessions.compactMap(\.approval).first { $0.id == id }
+    }
+
+    func notifyApprovalIfNeeded(_ approval: ApprovalRequest) {
+        guard ApprovalNotificationPolicy.shouldNotify(
+            enabled: configurationStore.config.enableApprovalNotifications,
+            doNotDisturb: configurationStore.config.doNotDisturb,
+            approval: approval
+        ) else { return }
+        approvalNotificationCenter.post(approval: approval, language: configurationStore.config.language)
     }
 
     func start() {
@@ -162,6 +192,9 @@ final class SessionStore: ObservableObject {
             startCodexDesktopRefreshTimer()
         } else {
             stopCodexDesktopRefreshTimer()
+        }
+        if configurationStore.config.enableApprovalNotifications {
+            approvalNotificationCenter.activate(language: configurationStore.config.language)
         }
         startVisibilityTimer()
     }

--- a/Sources/VibelslandFree/SettingsView.swift
+++ b/Sources/VibelslandFree/SettingsView.swift
@@ -46,6 +46,7 @@ struct SettingsView: View {
 
                 ApprovalPreferencesSection(
                     approvalTimeoutSeconds: binding(\.approvalTimeoutSeconds),
+                    approvalNotificationsEnabled: binding(\.enableApprovalNotifications),
                     approvalWaitText: approvalWaitText
                 )
 
@@ -502,6 +503,7 @@ private struct ApprovalPreferencesSection: View {
     @EnvironmentObject private var configurationStore: AppConfigurationStore
 
     @Binding var approvalTimeoutSeconds: TimeInterval
+    @Binding var approvalNotificationsEnabled: Bool
     let approvalWaitText: String
 
     var body: some View {
@@ -523,6 +525,22 @@ private struct ApprovalPreferencesSection: View {
                     .frame(width: 170)
                 }
                 SettingsDivider()
+                SettingsRow(icon: "bell.badge", title: AppText.pick(configurationStore.config.language, english: "System notifications", japanese: "システム通知", chinese: "系统通知")) {
+                    Toggle("", isOn: $approvalNotificationsEnabled)
+                        .labelsHidden()
+                }
+                Text(AppText.pick(
+                    configurationStore.config.language,
+                    english: "Posts a notification with Allow/Decline actions when an approval arrives, so requests are not missed while you are away. Respects Do Not Disturb. Requires macOS notification permission on first use.",
+                    japanese: "承認リクエスト到着時に許可/拒否アクション付きの通知を送り、離席中の見逃しを防ぎます。集中モード中は送信しません。初回は macOS の通知許可が必要です。",
+                    chinese: "审批到达时发送带允许/拒绝按钮的系统通知，人不在电脑前也不会错过；勿扰模式下不发送。首次使用需授予 macOS 通知权限。"
+                ))
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 8)
+                SettingsDivider()
+                    .padding(.top, 8)
                 Text(AppText.pick(
                     configurationStore.config.language,
                     english: "If the app is unavailable, requests fall back immediately. After the app takes over a request, timeout never auto-allows or auto-denies it.",

--- a/Sources/VibelslandFreeCore/AppConfiguration.swift
+++ b/Sources/VibelslandFreeCore/AppConfiguration.swift
@@ -48,6 +48,7 @@ package struct AppConfiguration: Codable, Equatable {
     package var approvalTimeoutSeconds: TimeInterval
     package var maxVisibleSessions: Int
     package var enableGlobalHotKeys: Bool
+    package var enableApprovalNotifications: Bool
 
     package static let `default` = AppConfiguration(
         enableClaude: true,
@@ -61,7 +62,8 @@ package struct AppConfiguration: Codable, Equatable {
         language: .english,
         approvalTimeoutSeconds: 7_200,
         maxVisibleSessions: 5,
-        enableGlobalHotKeys: false
+        enableGlobalHotKeys: false,
+        enableApprovalNotifications: false
     )
 
     package enum CodingKeys: String, CodingKey {
@@ -77,6 +79,7 @@ package struct AppConfiguration: Codable, Equatable {
         case approvalTimeoutSeconds
         case maxVisibleSessions
         case enableGlobalHotKeys
+        case enableApprovalNotifications
     }
 
     package init(
@@ -91,7 +94,8 @@ package struct AppConfiguration: Codable, Equatable {
         language: AppLanguage,
         approvalTimeoutSeconds: TimeInterval,
         maxVisibleSessions: Int,
-        enableGlobalHotKeys: Bool = false
+        enableGlobalHotKeys: Bool = false,
+        enableApprovalNotifications: Bool = false
     ) {
         self.enableClaude = enableClaude
         self.enableCodexCLI = enableCodexCLI
@@ -105,6 +109,7 @@ package struct AppConfiguration: Codable, Equatable {
         self.approvalTimeoutSeconds = approvalTimeoutSeconds
         self.maxVisibleSessions = maxVisibleSessions
         self.enableGlobalHotKeys = enableGlobalHotKeys
+        self.enableApprovalNotifications = enableApprovalNotifications
     }
 
     package init(from decoder: Decoder) throws {
@@ -121,6 +126,7 @@ package struct AppConfiguration: Codable, Equatable {
         approvalTimeoutSeconds = try container.decodeIfPresent(TimeInterval.self, forKey: .approvalTimeoutSeconds) ?? Self.default.approvalTimeoutSeconds
         maxVisibleSessions = try container.decodeIfPresent(Int.self, forKey: .maxVisibleSessions) ?? Self.default.maxVisibleSessions
         enableGlobalHotKeys = try container.decodeIfPresent(Bool.self, forKey: .enableGlobalHotKeys) ?? Self.default.enableGlobalHotKeys
+        enableApprovalNotifications = try container.decodeIfPresent(Bool.self, forKey: .enableApprovalNotifications) ?? Self.default.enableApprovalNotifications
     }
 }
 

--- a/Sources/VibelslandFreeCore/ApprovalNotificationPolicy.swift
+++ b/Sources/VibelslandFreeCore/ApprovalNotificationPolicy.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// 审批系统通知的纯逻辑：什么时候发、通知/动作标识符怎么编、动作怎么映射回审批决定。
+/// UserNotifications 框架的调用留在界面层，这里保持可单测。
+package enum ApprovalNotificationPolicy {
+    package static let categoryIdentifier = "free.vibelsland.approval"
+    package static let acceptActionIdentifier = "free.vibelsland.approval.accept"
+    package static let declineActionIdentifier = "free.vibelsland.approval.decline"
+
+    private static let notificationIdentifierPrefix = "free.vibelsland.approval.request."
+
+    package static func notificationIdentifier(approvalID: String) -> String {
+        notificationIdentifierPrefix + approvalID
+    }
+
+    package static func approvalID(fromNotificationIdentifier identifier: String) -> String? {
+        guard identifier.hasPrefix(notificationIdentifierPrefix) else { return nil }
+        let id = String(identifier.dropFirst(notificationIdentifierPrefix.count))
+        return id.isEmpty ? nil : id
+    }
+
+    /// 勿扰优先：用户开了勿扰就不打扰；已过期或已进入回传流程的审批不再通知。
+    package static func shouldNotify(
+        enabled: Bool,
+        doNotDisturb: Bool,
+        approval: ApprovalRequest
+    ) -> Bool {
+        guard enabled, !doNotDisturb else { return false }
+        guard !approval.isExpired else { return false }
+        return approval.resolutionState == .pending
+    }
+
+    /// 把通知动作映射回审批决定；只映射该审批实际支持的决定。
+    package static func decision(
+        forActionIdentifier identifier: String,
+        approval: ApprovalRequest
+    ) -> ApprovalDecision? {
+        let decision: ApprovalDecision
+        switch identifier {
+        case acceptActionIdentifier:
+            decision = .accept
+        case declineActionIdentifier:
+            decision = .decline
+        default:
+            return nil
+        }
+        return approval.supports(decision) ? decision : nil
+    }
+
+    /// 通知正文：优先命令详情，为空退回工具名，截断避免超长横幅。
+    package static func body(for approval: ApprovalRequest, limit: Int = 140) -> String {
+        let raw = approval.detail.isEmpty ? approval.tool : approval.detail
+        let flattened = raw
+            .replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard flattened.count > limit else { return flattened }
+        return String(flattened.prefix(limit)) + "…"
+    }
+}

--- a/Tests/VibelslandFreeCoreTests/ApprovalNotificationPolicyTests.swift
+++ b/Tests/VibelslandFreeCoreTests/ApprovalNotificationPolicyTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Testing
+@testable import VibelslandFreeCore
+
+@Suite
+struct ApprovalNotificationPolicyTests {
+    @Test func testNotificationIdentifierRoundTrip() {
+        let identifier = ApprovalNotificationPolicy.notificationIdentifier(approvalID: "claude-approval-42")
+        XCTAssertEqual(
+            ApprovalNotificationPolicy.approvalID(fromNotificationIdentifier: identifier),
+            "claude-approval-42",
+            "Identifier encodes and decodes the approval ID"
+        )
+        XCTAssertTrue(
+            ApprovalNotificationPolicy.approvalID(fromNotificationIdentifier: "other.notification") == nil,
+            "Foreign identifiers decode to nil"
+        )
+        XCTAssertTrue(
+            ApprovalNotificationPolicy.approvalID(
+                fromNotificationIdentifier: ApprovalNotificationPolicy.notificationIdentifier(approvalID: "")
+            ) == nil,
+            "Empty approval ID decodes to nil"
+        )
+    }
+
+    @Test func testShouldNotifyTruthTable() {
+        let pending = notificationApproval()
+        XCTAssertTrue(
+            ApprovalNotificationPolicy.shouldNotify(enabled: true, doNotDisturb: false, approval: pending),
+            "Enabled without DND notifies"
+        )
+        XCTAssertFalse(
+            ApprovalNotificationPolicy.shouldNotify(enabled: false, doNotDisturb: false, approval: pending),
+            "Disabled never notifies"
+        )
+        XCTAssertFalse(
+            ApprovalNotificationPolicy.shouldNotify(enabled: true, doNotDisturb: true, approval: pending),
+            "Do Not Disturb suppresses notifications"
+        )
+        XCTAssertFalse(
+            ApprovalNotificationPolicy.shouldNotify(
+                enabled: true,
+                doNotDisturb: false,
+                approval: notificationApproval(expired: true)
+            ),
+            "Expired approvals do not notify"
+        )
+        XCTAssertFalse(
+            ApprovalNotificationPolicy.shouldNotify(
+                enabled: true,
+                doNotDisturb: false,
+                approval: notificationApproval(resolutionState: .resolving)
+            ),
+            "Approvals already resolving do not notify"
+        )
+    }
+
+    @Test func testDecisionMappingHonorsAvailableDecisions() {
+        let approval = notificationApproval()
+        XCTAssertEqual(
+            ApprovalNotificationPolicy.decision(
+                forActionIdentifier: ApprovalNotificationPolicy.acceptActionIdentifier,
+                approval: approval
+            ),
+            .accept,
+            "Accept action maps to accept"
+        )
+        XCTAssertEqual(
+            ApprovalNotificationPolicy.decision(
+                forActionIdentifier: ApprovalNotificationPolicy.declineActionIdentifier,
+                approval: approval
+            ),
+            .decline,
+            "Decline action maps to decline"
+        )
+        XCTAssertTrue(
+            ApprovalNotificationPolicy.decision(forActionIdentifier: "unknown.action", approval: approval) == nil,
+            "Unknown actions map to nil"
+        )
+
+        let declineOnly = notificationApproval(availableDecisions: [.decline])
+        XCTAssertTrue(
+            ApprovalNotificationPolicy.decision(
+                forActionIdentifier: ApprovalNotificationPolicy.acceptActionIdentifier,
+                approval: declineOnly
+            ) == nil,
+            "Unsupported decisions map to nil even for known actions"
+        )
+    }
+
+    @Test func testBodyPrefersDetailAndTruncates() {
+        XCTAssertEqual(
+            ApprovalNotificationPolicy.body(for: notificationApproval(detail: "rm -rf build")),
+            "rm -rf build",
+            "Body uses the approval detail"
+        )
+        XCTAssertEqual(
+            ApprovalNotificationPolicy.body(for: notificationApproval(detail: "")),
+            "Bash",
+            "Empty detail falls back to the tool name"
+        )
+        let long = String(repeating: "x", count: 200)
+        let body = ApprovalNotificationPolicy.body(for: notificationApproval(detail: long))
+        XCTAssertEqual(body.count, 141, "Long bodies truncate to the limit plus ellipsis")
+        XCTAssertTrue(body.hasSuffix("…"), "Truncated bodies end with an ellipsis")
+        XCTAssertEqual(
+            ApprovalNotificationPolicy.body(for: notificationApproval(detail: "line one\nline two")),
+            "line one line two",
+            "Newlines flatten into single spaces"
+        )
+    }
+
+    @Test func testConfigurationDefaultsToDisabledAndDecodesLegacyConfig() throws {
+        XCTAssertFalse(AppConfiguration.default.enableApprovalNotifications, "Notifications are opt-in")
+
+        let legacyConfig = """
+        {
+          "enableClaude": true,
+          "enableCodexCLI": true,
+          "enableCodexDesktop": true,
+          "enableSounds": true,
+          "soundTheme": "soft",
+          "doNotDisturb": false,
+          "launchAtLogin": false,
+          "islandPosition": "topCenter",
+          "approvalTimeoutSeconds": 7200,
+          "maxVisibleSessions": 5
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AppConfiguration.self, from: legacyConfig)
+        XCTAssertFalse(decoded.enableApprovalNotifications, "Legacy configs without the key stay disabled")
+    }
+
+    private func notificationApproval(
+        detail: String = "run command",
+        availableDecisions: [ApprovalDecision] = [.accept, .decline],
+        expired: Bool = false,
+        resolutionState: ApprovalResolutionState = .pending
+    ) -> ApprovalRequest {
+        ApprovalRequest(
+            id: "approval-1",
+            source: .claudeCode,
+            title: "Approval",
+            detail: detail,
+            tool: "Bash",
+            workspace: "/tmp/vibelsland",
+            availableDecisions: availableDecisions,
+            suggestedSessionAllow: false,
+            supportsCancel: false,
+            isExpired: expired,
+            resolutionState: resolutionState,
+            createdAt: Date()
+        )
+    }
+}


### PR DESCRIPTION
## 概要

审批到达时发送 macOS 通知中心横幅，带**允许/拒绝**动作按钮，作为人不在浮岛前的兜底。默认关闭。

## 行为

- 勿扰模式抑制；审批解决/超时/过期后自动撤回通知。
- 点通知本体 → 打开浮岛并定位到该审批；动作按钮直接回传决定（仅映射该审批实际支持的决定）。
- 触发规则、标识符编码、动作映射、正文截断在 `ApprovalNotificationPolicy`（可单测）。
- 无 bundle 的裸可执行环境安全降级（避免 UNUserNotificationCenter 抛 ObjC 异常）。
- PRIVACY.md 已同步：通知内容不离开本机。

## 验证

- 编译通过；策略断言独立进程 16 项全过。

## 合并顺序

堆叠 PR 链第 **2/6** 个，base 为 `feat/global-hotkeys`，前序合并后 GitHub 会自动重定向到 main。

🤖 Generated with [Claude Code](https://claude.com/claude-code)