### PR TITLE
feat: add approval queue view for concurrent approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 
+- Added an approval queue in the expanded island: when several tools wait at once, approvals are listed oldest-first with inline Allow/Decline per row, an overflow count, and a pending-approval count on the compact pill.
 - Added optional approval notifications: macOS Notification Center banners with Allow/Decline actions as a fallback when you are away from the island (off by default, withdrawn once the approval resolves, suppressed by Do Not Disturb).
 - Added optional global hotkeys: ⌃⌥I toggles the island and ⌃⌥A jumps to the pending approval (off by default, no extra permissions required).
 - Added Japanese README and Japanese documentation pages.

--- a/Sources/VibelslandFree/AppText.swift
+++ b/Sources/VibelslandFree/AppText.swift
@@ -80,6 +80,17 @@ enum AppText {
         }
     }
 
+    static func approvalOverflow(_ count: Int, language: AppLanguage) -> String {
+        switch language {
+        case .english:
+            return count == 1 ? "+1 more waiting" : "+\(count) more waiting"
+        case .japanese:
+            return "ほか \(count) 件が待機中"
+        case .chinese:
+            return "还有 \(count) 个等待中"
+        }
+    }
+
     static func subagents(_ active: Int, total: Int, language: AppLanguage) -> String {
         let value = active == total ? "\(active)" : "\(active)/\(total)"
         switch language {

--- a/Sources/VibelslandFree/IslandDashboardViews.swift
+++ b/Sources/VibelslandFree/IslandDashboardViews.swift
@@ -506,6 +506,140 @@ struct ApprovalSummaryCard: View {
     }
 }
 
+struct ApprovalQueueCard: View {
+    @EnvironmentObject private var store: SessionStore
+    @EnvironmentObject private var configurationStore: AppConfigurationStore
+    let sessions: [AgentSession]
+    let onShowDetail: (AgentSession) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: ApprovalQueuePolicy.elementSpacing) {
+            HStack(spacing: 6) {
+                Image(systemName: "hand.raised.fill")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(.yellow)
+                Text(AppText.pendingApprovals(ApprovalQueuePolicy.count(in: store.sessions), language: configurationStore.config.language))
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(GlassText.primary)
+                Spacer()
+            }
+            .frame(height: ApprovalQueuePolicy.headerHeight)
+
+            ForEach(visibleSessions) { session in
+                if let approval = session.approval {
+                    ApprovalQueueRow(
+                        session: session,
+                        approval: approval,
+                        onShowDetail: { onShowDetail(session) }
+                    )
+                    .environmentObject(store)
+                }
+            }
+
+            if overflowCount > 0 {
+                Text(AppText.approvalOverflow(overflowCount, language: configurationStore.config.language))
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(GlassText.tertiary)
+                    .frame(height: ApprovalQueuePolicy.overflowFooterHeight)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, ApprovalQueuePolicy.cardVerticalPadding)
+        .background(
+            ZStack {
+                DashboardCardBackground(highlighted: true, tint: Color.yellow.opacity(0.08))
+                StatusGlowBorder(
+                    status: .waitingApproval,
+                    accentColor: .orange,
+                    cornerRadius: 18,
+                    lineWidth: 1.1,
+                    glowRadius: 6,
+                    intensity: 0.86
+                )
+            }
+        )
+        .contentShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+    }
+
+    private var visibleSessions: [AgentSession] {
+        Array(sessions.prefix(ApprovalQueuePolicy.maximumVisibleRows))
+    }
+
+    private var overflowCount: Int {
+        max(0, sessions.count - ApprovalQueuePolicy.maximumVisibleRows)
+    }
+}
+
+private struct ApprovalQueueRow: View {
+    @EnvironmentObject private var store: SessionStore
+    @EnvironmentObject private var configurationStore: AppConfigurationStore
+    let session: AgentSession
+    let approval: ApprovalRequest
+    let onShowDetail: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Button(action: onShowDetail) {
+                HStack(spacing: 8) {
+                    AgentSourceIconView(source: session.source, size: 26, status: .waitingApproval)
+                        .frame(width: 26, height: 26)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("\(approval.source.shortName) · \(approval.tool)")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(GlassText.primary)
+                            .lineLimit(1)
+                        Text(approval.detail.isEmpty ? workspaceText : approval.detail)
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(GlassText.secondary)
+                            .lineLimit(1)
+                    }
+                    Spacer(minLength: 4)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help(AppText.pick(configurationStore.config.language, english: "View approval details", japanese: "承認詳細を表示", chinese: "查看审批详情"))
+
+            if approval.supports(.accept) {
+                queueActionButton(ApprovalDecision.accept.title(language: configurationStore.config.language), .accept, prominent: true)
+            }
+            if approval.supports(.decline) {
+                queueActionButton(ApprovalDecision.decline.title(language: configurationStore.config.language), .decline)
+            }
+        }
+        .frame(height: ApprovalQueuePolicy.rowHeight)
+    }
+
+    private func queueActionButton(_ title: String, _ decision: ApprovalDecision, prominent: Bool = false) -> some View {
+        Button(title) {
+            store.resolveApproval(approval, decision: decision)
+        }
+        .font(.system(size: 11, weight: .semibold))
+        .lineLimit(1)
+        .minimumScaleFactor(0.82)
+        .padding(.horizontal, 8)
+        .frame(height: 24)
+        .background(
+            ClearGlassCapsuleBackground(
+                highlighted: prominent,
+                tint: prominent ? Color.white.opacity(0.16) : Color.white.opacity(0.030),
+                materialOpacity: prominent ? 0.62 : 0.42
+            )
+        )
+        .foregroundStyle(prominent ? Color(red: 0.12, green: 0.42, blue: 0.84) : GlassText.primary)
+        .clipShape(Capsule())
+        .buttonStyle(.plain)
+        .disabled(approval.isResolving || approval.isExpired)
+    }
+
+    private var workspaceText: String {
+        guard let workspace = approval.workspace, !workspace.isEmpty else {
+            return approval.tool
+        }
+        return URL(fileURLWithPath: workspace).lastPathComponent
+    }
+}
+
 struct ApprovalDetailCard: View {
     @EnvironmentObject private var store: SessionStore
     @EnvironmentObject private var configurationStore: AppConfigurationStore

--- a/Sources/VibelslandFree/IslandPanelView.swift
+++ b/Sources/VibelslandFree/IslandPanelView.swift
@@ -253,24 +253,30 @@ struct IslandPanelView: View {
                 HealthSummaryStrip(items: store.healthChecks)
             }
 
-            if let approvalSession = pendingApprovalSession,
+            if showingApprovalDetail,
+               let approvalSession = approvalDetailSession,
                let approval = approvalSession.approval {
-                if showingApprovalDetail {
-                    ApprovalDetailCard(session: approvalSession, approval: approval) {
-                        showingApprovalDetail = false
-                    }
-                    .environmentObject(store)
-                } else {
-                    ApprovalSummaryCard(
-                        session: approvalSession,
-                        approval: approval,
-                        showsDetail: $showingApprovalDetail
-                    )
-                    .environmentObject(store)
+                ApprovalDetailCard(session: approvalSession, approval: approval) {
+                    showingApprovalDetail = false
                 }
+                .environmentObject(store)
+            } else if approvalQueueSessions.count > 1 {
+                ApprovalQueueCard(sessions: approvalQueueSessions) { session in
+                    store.selectedSessionID = session.id
+                    showingApprovalDetail = true
+                }
+                .environmentObject(store)
+            } else if let approvalSession = approvalQueueSessions.first,
+                      let approval = approvalSession.approval {
+                ApprovalSummaryCard(
+                    session: approvalSession,
+                    approval: approval,
+                    showsDetail: $showingApprovalDetail
+                )
+                .environmentObject(store)
             }
 
-            if showingApprovalDetail && pendingApprovalSession != nil {
+            if showingApprovalDetail && approvalDetailSession != nil {
                 EmptyView()
             } else if dashboardSessions.isEmpty {
                 DashboardEmptyCard()
@@ -288,9 +294,9 @@ struct IslandPanelView: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .onChange(of: showingApprovalDetail) { _, value in
-            store.isApprovalDetailVisible = value && pendingApprovalSession != nil
+            store.isApprovalDetailVisible = value && approvalDetailSession != nil
         }
-        .onChange(of: pendingApprovalSession?.approval?.id) {
+        .onChange(of: approvalDetailSession?.approval?.id) {
             showingApprovalDetail = false
             store.isApprovalDetailVisible = false
         }
@@ -374,6 +380,10 @@ struct IslandPanelView: View {
             return AppText.pick(configurationStore.config.language, english: "Waiting for events", japanese: "イベント待ち", chinese: "等待事件")
         }
         if session.approval != nil {
+            let queueCount = approvalQueueSessions.count
+            if queueCount > 1 {
+                return AppText.pendingApprovals(queueCount, language: configurationStore.config.language)
+            }
             return AppText.pick(configurationStore.config.language, english: "Waiting approval", japanese: "承認待ち", chinese: "等待审批")
         }
         let display = SessionDisplaySnapshot(session: session, language: configurationStore.config.language)
@@ -489,6 +499,20 @@ struct IslandPanelView: View {
         DashboardSessionPolicy.pendingApprovalSession(in: store.sessions)
     }
 
+    private var approvalQueueSessions: [AgentSession] {
+        ApprovalQueuePolicy.queue(in: store.sessions)
+    }
+
+    /// 详情优先展示用户点选的审批，未点选时退回等待最久的主审批。
+    private var approvalDetailSession: AgentSession? {
+        if let selected = store.selectedSession,
+           let approval = selected.approval,
+           !approval.isExpired {
+            return selected
+        }
+        return pendingApprovalSession
+    }
+
     private var dashboardUsage: UsageSnapshot? {
         dashboardVisibleSessions.first { session in
             guard let usage = session.usage else { return false }
@@ -497,11 +521,11 @@ struct IslandPanelView: View {
     }
 
     private var dashboardSessions: [AgentSession] {
-        let approvalID = pendingApprovalSession?.id
-        let limit = configuredVisibleSessionLimit - (pendingApprovalSession == nil ? 0 : 1)
+        let queueIDs = Set(approvalQueueSessions.map(\.id))
+        let limit = configuredVisibleSessionLimit - (queueIDs.isEmpty ? 0 : 1)
         return DashboardSessionPolicy.visibleSessions(
             from: store.sessions,
-            excluding: approvalID,
+            excludingIDs: queueIDs,
             limit: max(0, limit)
         )
     }

--- a/Sources/VibelslandFree/IslandWindow.swift
+++ b/Sources/VibelslandFree/IslandWindow.swift
@@ -643,8 +643,8 @@ final class IslandWindow: NSPanel {
 
     private func expandedPreferredHeight() -> CGFloat {
         guard let store else { return 170 }
-        let pendingApproval = DashboardSessionPolicy.pendingApprovalSession(in: store.sessions)
-        let hasPendingApproval = pendingApproval != nil
+        let approvalQueue = ApprovalQueuePolicy.queue(in: store.sessions)
+        let hasPendingApproval = !approvalQueue.isEmpty
         let hasHealthWarning = store.healthChecks.contains { $0.status == .needsAction }
         let isShowingApprovalDetail = store.isApprovalDetailVisible && hasPendingApproval
         let configuredLimit = DashboardSessionPolicy.configuredVisibleSessionLimit(
@@ -653,7 +653,7 @@ final class IslandWindow: NSPanel {
 
         let visibleSessionCount = DashboardSessionPolicy.visibleSessions(
             from: store.sessions,
-            excluding: pendingApproval?.id,
+            excludingIDs: Set(approvalQueue.map(\.id)),
             limit: hasPendingApproval
                 ? max(0, configuredLimit - 1)
                 : configuredLimit
@@ -670,6 +670,9 @@ final class IslandWindow: NSPanel {
         if hasPendingApproval {
             if isShowingApprovalDetail {
                 height += 178 + rowSpacing
+            } else if approvalQueue.count > 1 {
+                height += ApprovalQueuePolicy.cardHeight(in: store.sessions) + rowSpacing
+                height += CGFloat(visibleSessionCount) * (48 + rowSpacing)
             } else {
                 height += 88 + rowSpacing
                 height += CGFloat(visibleSessionCount) * (48 + rowSpacing)

--- a/Sources/VibelslandFreeCore/ApprovalQueuePolicy.swift
+++ b/Sources/VibelslandFreeCore/ApprovalQueuePolicy.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// 多审批并存时的队列策略：排序、主审批选取、可见行数与队列卡片高度。
+/// 队列卡片高度放在这里，是为了让 SwiftUI 布局和 IslandWindow 的窗口高度
+/// 计算共用同一套数字，避免两处失同步。
+package enum ApprovalQueuePolicy {
+    package static let maximumVisibleRows = 3
+
+    /// 队列卡片布局常量（与 ApprovalQueueCard 的实际布局一一对应）。
+    package static let cardVerticalPadding: CGFloat = 10
+    package static let headerHeight: CGFloat = 20
+    package static let rowHeight: CGFloat = 44
+    package static let elementSpacing: CGFloat = 6
+    package static let overflowFooterHeight: CGFloat = 14
+
+    /// 按发起时间从早到晚排序的待审批会话（未过期）。
+    package static func queue(in sessions: [AgentSession]) -> [AgentSession] {
+        sessions
+            .filter { session in
+                guard let approval = session.approval else { return false }
+                return !approval.isExpired
+            }
+            .sorted { lhs, rhs in
+                (lhs.approval?.createdAt ?? .distantFuture) < (rhs.approval?.createdAt ?? .distantFuture)
+            }
+    }
+
+    package static func count(in sessions: [AgentSession]) -> Int {
+        queue(in: sessions).count
+    }
+
+    /// 主审批 = 等待最久的那一个。
+    package static func primarySession(in sessions: [AgentSession]) -> AgentSession? {
+        queue(in: sessions).first
+    }
+
+    package static func visibleRows(in sessions: [AgentSession]) -> [AgentSession] {
+        Array(queue(in: sessions).prefix(maximumVisibleRows))
+    }
+
+    package static func overflowCount(in sessions: [AgentSession]) -> Int {
+        max(0, count(in: sessions) - maximumVisibleRows)
+    }
+
+    package static func cardHeight(rowCount: Int, overflowCount: Int) -> CGFloat {
+        guard rowCount > 0 else { return 0 }
+        let hasOverflow = overflowCount > 0
+        let elementGaps = CGFloat(rowCount + (hasOverflow ? 1 : 0)) * elementSpacing
+        var height = cardVerticalPadding * 2
+        height += headerHeight
+        height += CGFloat(rowCount) * rowHeight
+        height += hasOverflow ? overflowFooterHeight : 0
+        height += elementGaps
+        return height
+    }
+
+    package static func cardHeight(in sessions: [AgentSession]) -> CGFloat {
+        cardHeight(
+            rowCount: visibleRows(in: sessions).count,
+            overflowCount: overflowCount(in: sessions)
+        )
+    }
+}

--- a/Sources/VibelslandFreeCore/DashboardSessionPolicy.swift
+++ b/Sources/VibelslandFreeCore/DashboardSessionPolicy.swift
@@ -14,12 +14,26 @@ package enum DashboardSessionPolicy {
         limit: Int = maximumVisibleSessions,
         now: Date = Date()
     ) -> [AgentSession] {
+        visibleSessions(
+            from: sessions,
+            excludingIDs: excludedID.map { [$0] } ?? [],
+            limit: limit,
+            now: now
+        )
+    }
+
+    package static func visibleSessions(
+        from sessions: [AgentSession],
+        excludingIDs excludedIDs: Set<AgentSession.ID>,
+        limit: Int = maximumVisibleSessions,
+        now: Date = Date()
+    ) -> [AgentSession] {
         let boundedLimit = max(0, min(limit, maximumVisibleSessions))
         guard boundedLimit > 0 else { return [] }
 
         let candidates = sessions
             .filter { session in
-                session.id != excludedID && isVisible(session, now: now)
+                !excludedIDs.contains(session.id) && isVisible(session, now: now)
             }
             .sorted { lhs, rhs in
                 lhs.updatedAt > rhs.updatedAt
@@ -80,10 +94,8 @@ package enum DashboardSessionPolicy {
         }
     }
 
+    /// 主审批与队列排序保持一致：等待最久的排最前。
     package static func pendingApprovalSession(in sessions: [AgentSession]) -> AgentSession? {
-        sessions.first { session in
-            guard let approval = session.approval else { return false }
-            return !approval.isExpired
-        }
+        ApprovalQueuePolicy.primarySession(in: sessions)
     }
 }

--- a/Sources/VibelslandFreeCore/GlobalHotKeyPolicy.swift
+++ b/Sources/VibelslandFreeCore/GlobalHotKeyPolicy.swift
@@ -45,16 +45,8 @@ package enum GlobalHotKeyPolicy {
         GlobalHotKeyAction.allCases.first { $0.carbonHotKeyID == id }
     }
 
-    /// 跳转目标：最早发起且仍未过期的审批所在会话。
+    /// 跳转目标：审批队列里等待最久的会话（与浮岛主审批一致）。
     package static func approvalTargetSessionID(in sessions: [AgentSession]) -> AgentSession.ID? {
-        sessions
-            .filter { session in
-                guard let approval = session.approval else { return false }
-                return !approval.isExpired
-            }
-            .min { lhs, rhs in
-                (lhs.approval?.createdAt ?? .distantFuture) < (rhs.approval?.createdAt ?? .distantFuture)
-            }?
-            .id
+        ApprovalQueuePolicy.primarySession(in: sessions)?.id
     }
 }

--- a/Sources/VibelslandFreeCore/IslandLayoutSignature.swift
+++ b/Sources/VibelslandFreeCore/IslandLayoutSignature.swift
@@ -6,6 +6,7 @@ package struct IslandLayoutSignature: Equatable {
     package var presentationMode: IslandPresentationMode
     package var hasHealthWarning: Bool
     package var pendingApprovalID: AgentSession.ID?
+    package var pendingApprovalCount: Int
     package var visibleSessionCount: Int
     package var isShowingApprovalDetail: Bool
 
@@ -18,7 +19,8 @@ package struct IslandLayoutSignature: Equatable {
         position: IslandPosition,
         now: Date = Date()
     ) {
-        let pendingApproval = DashboardSessionPolicy.pendingApprovalSession(in: sessions)
+        let approvalQueue = ApprovalQueuePolicy.queue(in: sessions)
+        let pendingApproval = approvalQueue.first
         let configuredLimit = DashboardSessionPolicy.configuredVisibleSessionLimit(maxVisibleSessions)
         self.isExpanded = isExpanded
         self.position = position
@@ -29,9 +31,10 @@ package struct IslandLayoutSignature: Equatable {
         )
         self.hasHealthWarning = healthChecks.contains { $0.status == .needsAction }
         self.pendingApprovalID = pendingApproval?.id
+        self.pendingApprovalCount = approvalQueue.count
         self.visibleSessionCount = DashboardSessionPolicy.visibleSessions(
             from: sessions,
-            excluding: pendingApproval?.id,
+            excludingIDs: Set(approvalQueue.map(\.id)),
             limit: pendingApproval == nil ? configuredLimit : max(0, configuredLimit - 1),
             now: now
         ).count

--- a/Tests/VibelslandFreeCoreTests/ApprovalQueuePolicyTests.swift
+++ b/Tests/VibelslandFreeCoreTests/ApprovalQueuePolicyTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Testing
+@testable import VibelslandFreeCore
+
+@Suite
+struct ApprovalQueuePolicyTests {
+    @Test func testQueueOrdersByOldestApprovalAndSkipsExpired() {
+        let now = Date()
+        let sessions = [
+            queueSession(id: "plain", approvalCreatedAt: nil),
+            queueSession(id: "newest", approvalCreatedAt: now),
+            queueSession(id: "oldest", approvalCreatedAt: now.addingTimeInterval(-300)),
+            queueSession(id: "middle", approvalCreatedAt: now.addingTimeInterval(-60)),
+            queueSession(id: "expired", approvalCreatedAt: now.addingTimeInterval(-900), expired: true)
+        ]
+        let queue = ApprovalQueuePolicy.queue(in: sessions)
+        XCTAssertEqual(queue.map(\.id), ["oldest", "middle", "newest"], "Queue sorts oldest first and drops expired")
+        XCTAssertEqual(ApprovalQueuePolicy.count(in: sessions), 3, "Count matches queue size")
+        XCTAssertEqual(ApprovalQueuePolicy.primarySession(in: sessions)?.id, "oldest", "Primary is the oldest approval")
+    }
+
+    @Test func testPrimarySelectionStaysConsistentAcrossPolicies() {
+        let now = Date()
+        let sessions = [
+            queueSession(id: "newer", approvalCreatedAt: now),
+            queueSession(id: "older", approvalCreatedAt: now.addingTimeInterval(-120))
+        ]
+        let primaryID = ApprovalQueuePolicy.primarySession(in: sessions)?.id
+        XCTAssertEqual(
+            DashboardSessionPolicy.pendingApprovalSession(in: sessions)?.id,
+            primaryID,
+            "Dashboard primary approval matches the queue"
+        )
+        XCTAssertEqual(
+            GlobalHotKeyPolicy.approvalTargetSessionID(in: sessions),
+            primaryID,
+            "Hotkey jump target matches the queue"
+        )
+    }
+
+    @Test func testVisibleRowsAndOverflow() {
+        let now = Date()
+        let sessions = (0..<5).map { index in
+            queueSession(id: "s\(index)", approvalCreatedAt: now.addingTimeInterval(TimeInterval(-index)))
+        }
+        XCTAssertEqual(
+            ApprovalQueuePolicy.visibleRows(in: sessions).count,
+            ApprovalQueuePolicy.maximumVisibleRows,
+            "Visible rows cap at the maximum"
+        )
+        XCTAssertEqual(ApprovalQueuePolicy.overflowCount(in: sessions), 2, "Overflow counts the hidden approvals")
+
+        let two = Array(sessions.prefix(2))
+        XCTAssertEqual(ApprovalQueuePolicy.visibleRows(in: two).count, 2, "Small queues show every row")
+        XCTAssertEqual(ApprovalQueuePolicy.overflowCount(in: two), 0, "Small queues have no overflow")
+    }
+
+    @Test func testCardHeightFormula() {
+        XCTAssertEqual(ApprovalQueuePolicy.cardHeight(rowCount: 0, overflowCount: 0), 0, "Empty queue renders no card")
+
+        let two = ApprovalQueuePolicy.cardHeight(rowCount: 2, overflowCount: 0)
+        let expectedTwo = ApprovalQueuePolicy.cardVerticalPadding * 2
+            + ApprovalQueuePolicy.headerHeight
+            + 2 * ApprovalQueuePolicy.rowHeight
+            + 2 * ApprovalQueuePolicy.elementSpacing
+        XCTAssertEqual(two, expectedTwo, "Two-row card height matches layout constants")
+
+        let threeOverflow = ApprovalQueuePolicy.cardHeight(rowCount: 3, overflowCount: 2)
+        let expectedThree = ApprovalQueuePolicy.cardVerticalPadding * 2
+            + ApprovalQueuePolicy.headerHeight
+            + 3 * ApprovalQueuePolicy.rowHeight
+            + ApprovalQueuePolicy.overflowFooterHeight
+            + 4 * ApprovalQueuePolicy.elementSpacing
+        XCTAssertEqual(threeOverflow, expectedThree, "Overflow adds footer height plus one gap")
+        XCTAssertTrue(threeOverflow > two, "Height grows with the queue")
+    }
+
+    @Test func testVisibleSessionsExcludingIDSetMatchesSingleExclusion() {
+        let now = Date()
+        let approvalA = queueSession(id: "approval-a", approvalCreatedAt: now.addingTimeInterval(-10))
+        let approvalB = queueSession(id: "approval-b", approvalCreatedAt: now)
+        let worker = queueSession(id: "worker", approvalCreatedAt: nil)
+        let sessions = [approvalA, approvalB, worker]
+
+        let excludedBoth = DashboardSessionPolicy.visibleSessions(
+            from: sessions,
+            excludingIDs: ["approval-a", "approval-b"]
+        )
+        XCTAssertEqual(excludedBoth.map(\.id), ["worker"], "Set exclusion removes every queued session")
+
+        let single = DashboardSessionPolicy.visibleSessions(from: sessions, excluding: "approval-a")
+        XCTAssertTrue(
+            single.contains { $0.id == "approval-b" },
+            "Single-ID exclusion keeps the other sessions"
+        )
+    }
+
+    private func queueSession(
+        id: String,
+        approvalCreatedAt: Date?,
+        expired: Bool = false
+    ) -> AgentSession {
+        let approval = approvalCreatedAt.map { createdAt in
+            ApprovalRequest(
+                id: "approval-\(id)",
+                source: .claudeCode,
+                title: "Approval",
+                detail: "run command",
+                tool: "Bash",
+                workspace: "/tmp/vibelsland",
+                suggestedSessionAllow: false,
+                supportsCancel: false,
+                isExpired: expired,
+                createdAt: createdAt
+            )
+        }
+        return AgentSession(
+            id: id,
+            title: id,
+            prompt: id,
+            source: .claudeCode,
+            workspace: "/tmp/vibelsland",
+            terminal: "Claude Code",
+            updatedAt: Date(),
+            status: approval == nil ? .runningTool : .waitingApproval,
+            activity: [],
+            approval: approval,
+            question: nil,
+            subagents: [],
+            lastAssistantMessage: nil,
+            lastUserMessage: nil,
+            usage: nil
+        )
+    }
+}

--- a/scripts/verify-approval-queue-window.sh
+++ b/scripts/verify-approval-queue-window.sh
@@ -1,0 +1,99 @@
+#!/bin/zsh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APP_DIR="$ROOT/dist/>_ - island.app"
+EXECUTABLE="$APP_DIR/Contents/MacOS/VibelslandFree"
+WINDOW_CHECKER="$ROOT/scripts/window-check.swift"
+WAIT_SECONDS="${VIBELSLAND_APPROVAL_WINDOW_SECONDS:-5}"
+# 队列卡片（2 行 = 140pt）比单审批卡（88pt）高 52pt：
+# 单审批窗口约 236pt，两个审批的队列窗口必须明显更高才算通过。
+MIN_WIDTH="${VIBELSLAND_APPROVAL_QUEUE_MIN_WIDTH:-500}"
+MAX_WIDTH="${VIBELSLAND_APPROVAL_QUEUE_MAX_WIDTH:-700}"
+MIN_HEIGHT="${VIBELSLAND_APPROVAL_QUEUE_MIN_HEIGHT:-250}"
+MAX_HEIGHT="${VIBELSLAND_APPROVAL_QUEUE_MAX_HEIGHT:-400}"
+
+[[ -d "$APP_DIR" ]]
+[[ -x "$EXECUTABLE" ]]
+[[ -f "$WINDOW_CHECKER" ]]
+. "$ROOT/scripts/verify-support.sh"
+
+TEMP_HOME="$(/usr/bin/mktemp -d "/tmp/vibelsland-approval-queue-home.XXXXXX")"
+APP_PID=""
+LOG="$(vibelsland_log_path "$TEMP_HOME")"
+
+cleanup() {
+    vibelsland_cleanup_temp_home "$TEMP_HOME" "$APP_PID"
+}
+trap cleanup EXIT
+
+vibelsland_write_test_config "$TEMP_HOME" \
+    enableClaude=true \
+    enableCodexCLI=true \
+    enableCodexDesktop=false \
+    enableSounds=false \
+    soundTheme=soft \
+    doNotDisturb=false \
+    launchAtLogin=false \
+    islandPosition=topCenter \
+    approvalTimeoutSeconds=7200 \
+    maxVisibleSessions=5
+
+(
+    export VIBELSLAND_HOME="$TEMP_HOME"
+    "$EXECUTABLE" >/dev/null 2>&1
+) &
+APP_PID="$!"
+
+sleep "$WAIT_SECONDS"
+
+if ! /bin/kill -0 "$APP_PID" >/dev/null 2>&1; then
+    echo "Approval queue verification failed: app process exited early" >&2
+    exit 1
+fi
+
+BRIDGE="$(vibelsland_bridge_path "$TEMP_HOME")"
+SOCKET="$(vibelsland_socket_path "$TEMP_HOME")"
+for _ in {1..60}; do
+    if [[ -x "$BRIDGE" && -S "$SOCKET" ]]; then
+        break
+    fi
+    sleep 0.2
+done
+
+[[ -x "$BRIDGE" ]]
+[[ -S "$SOCKET" ]]
+
+SMOKE_ID="vibelsland-approval-queue-$(/bin/date +%s)-$$"
+SMOKE_WORKSPACE="/tmp/$SMOKE_ID"
+
+send_approval() {
+    local session_suffix="$1"
+    local command="$2"
+    (
+        export HOME="$TEMP_HOME"
+        export VIBELSLAND_BRIDGE_TIMEOUT=1
+        printf '%s\n' "{\"hook_event_name\":\"PermissionRequest\",\"session_id\":\"$SMOKE_ID-$session_suffix\",\"cwd\":\"$SMOKE_WORKSPACE-$session_suffix\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$command\"},\"permission_suggestions\":[{\"type\":\"session\",\"pattern\":\"Bash($command)\"}]}" | "$BRIDGE" --source claude >/dev/null
+    ) || true
+}
+
+send_approval "first" "echo first approval"
+send_approval "second" "echo second approval"
+
+output=""
+for _ in {1..25}; do
+    if output="$(/usr/bin/swift "$WINDOW_CHECKER" "$APP_PID" "$MIN_WIDTH" "$MAX_WIDTH" "$MIN_HEIGHT" "$MAX_HEIGHT" "Approval queue" 2>&1)"; then
+        if [[ -f "$LOG" ]] && [[ "$(/usr/bin/grep -c 'event.ingest claudeCode approval' "$LOG")" -ge 2 ]]; then
+            echo "Approval queue verification passed: $output"
+            exit 0
+        fi
+    fi
+    sleep 0.2
+done
+
+echo "Approval queue verification failed: queue window size was not reached" >&2
+echo "$output" >&2
+if [[ -f "$LOG" ]]; then
+    /usr/bin/tail -80 "$LOG" >&2
+fi
+exit 1


### PR DESCRIPTION
## 概要

多个工具同时等审批时，展开面板显示**审批队列**：按等待时长排序（最久优先）、每行内联允许/拒绝、最多 3 行 + 溢出计数，紧凑药丸显示待审批数。

## 实现

- `ApprovalQueuePolicy` 统一排序、可见行数、队列卡片高度公式——SwiftUI 布局和 `IslandWindow` 窗口高度共用一套数字，防止失同步。
- 主审批选取（面板/布局签名/快捷键跳转）统一为「等待最久优先」。
- `DashboardSessionPolicy.visibleSessions` 新增 ID 集合排除，队列会话不再重复出现在会话列表。
- 新增 `verify-approval-queue-window.sh` 端到端脚本。

## 验证

- 真实 App 窗口自动化：双审批队列窗口 **288pt**，恰比单审批 236pt 高 52pt（140 队列卡 vs 88 单卡），高度公式端到端吻合；单审批场景回归通过。
- 策略断言独立进程 10 项全过。

## 合并顺序

堆叠 PR 链第 **3/6** 个，base 为 `feat/approval-notifications`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)