### PR TITLE
feat: add opt-in update checker backed by GitHub releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 
+- Added an update checker in settings: a manual "Check for updates" button plus an optional launch-time check (off by default); the GitHub releases API is contacted only on explicit user action, keeping the local-first promise.
 - Added an approval queue in the expanded island: when several tools wait at once, approvals are listed oldest-first with inline Allow/Decline per row, an overflow count, and a pending-approval count on the compact pill.
 - Added optional approval notifications: macOS Notification Center banners with Allow/Decline actions as a fallback when you are away from the island (off by default, withdrawn once the approval resolves, suppressed by Do Not Disturb).
 - Added optional global hotkeys: ⌃⌥I toggles the island and ⌃⌥A jumps to the pending approval (off by default, no extra permissions required).

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -36,6 +36,8 @@ Logs stay on the user's Mac until the user deletes them. The app does not curren
 
 &gt;_ - island does not require an internet connection for its core features. Claude Code, Codex CLI, and Codex Desktop may use their own network connections independently of this app.
 
+The optional update check is the only network feature. It contacts the GitHub releases API (`api.github.com`) only when the user clicks "Check for updates" or enables the launch-time check in settings (off by default). The request carries no account data, no session content, and no telemetry; the response is public release metadata used to compare version numbers.
+
 Vibelsland Free is an independent project. It is not affiliated with Anthropic, OpenAI, Claude, or Codex.
 
 ## Distribution Trust

--- a/Sources/VibelslandFree/SessionStore.swift
+++ b/Sources/VibelslandFree/SessionStore.swift
@@ -25,6 +25,7 @@ final class SessionStore: ObservableObject {
     @Published var isApprovalDetailVisible = false
     @Published var healthChecks: [HealthCheckItem] = []
     @Published var sessionVisibilityRefreshToken = 0
+    @Published var updateCheckState: UpdateCheckState = .idle
 
     let configurationStore: AppConfigurationStore
 
@@ -152,6 +153,30 @@ final class SessionStore: ObservableObject {
         sessions.compactMap(\.approval).first { $0.id == id }
     }
 
+    func checkForUpdates() {
+        guard updateCheckState != .checking else { return }
+        updateCheckState = .checking
+        let checker = UpdateChecker()
+        Task { @MainActor [weak self] in
+            let result = await checker.fetchLatestRelease()
+            guard let self else { return }
+            let current = UpdateChecker.currentVersion
+            switch result {
+            case .success(let release):
+                if UpdateCheckPolicy.isNewer(remote: release.version, current: current) {
+                    self.updateCheckState = .available(release)
+                    self.logger.info("update.check.available", detail: release.version)
+                } else {
+                    self.updateCheckState = .upToDate(current: current)
+                    self.logger.info("update.check.upToDate", detail: current)
+                }
+            case .failure(let error):
+                self.updateCheckState = .failed(message: error.localizedDescription)
+                self.logger.info("update.check.failed", detail: error.localizedDescription)
+            }
+        }
+    }
+
     func notifyApprovalIfNeeded(_ approval: ApprovalRequest) {
         guard ApprovalNotificationPolicy.shouldNotify(
             enabled: configurationStore.config.enableApprovalNotifications,
@@ -195,6 +220,9 @@ final class SessionStore: ObservableObject {
         }
         if configurationStore.config.enableApprovalNotifications {
             approvalNotificationCenter.activate(language: configurationStore.config.language)
+        }
+        if configurationStore.config.autoCheckUpdates {
+            checkForUpdates()
         }
         startVisibilityTimer()
     }

--- a/Sources/VibelslandFree/SettingsView.swift
+++ b/Sources/VibelslandFree/SettingsView.swift
@@ -58,6 +58,12 @@ struct SettingsView: View {
                     openLogs: store.openLogs
                 )
 
+                UpdateSection(
+                    autoCheckUpdates: binding(\.autoCheckUpdates),
+                    state: store.updateCheckState,
+                    check: store.checkForUpdates
+                )
+
                 DiagnosticsSection(
                     codexAppServerReachable: store.codexAppServerReachable,
                     codexAppServerThreadListAvailable: store.codexAppServerThreadListAvailable,
@@ -553,6 +559,87 @@ private struct ApprovalPreferencesSection: View {
                     .padding(.top, 10)
             }
         }
+    }
+}
+
+private struct UpdateSection: View {
+    @EnvironmentObject private var configurationStore: AppConfigurationStore
+
+    @Binding var autoCheckUpdates: Bool
+    let state: UpdateCheckState
+    let check: () -> Void
+
+    var body: some View {
+        SettingsCard(
+            title: AppText.pick(configurationStore.config.language, english: "Updates", japanese: "アップデート", chinese: "更新"),
+            subtitle: AppText.pick(
+                configurationStore.config.language,
+                english: "Checks the GitHub releases page only when you ask; nothing is sent automatically.",
+                japanese: "GitHub のリリースページへの確認は手動または明示的な設定時のみ行います。",
+                chinese: "只在你主动检查或开启自动检查时访问 GitHub 发布页，不会自动上报任何数据。"
+            )
+        ) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 10) {
+                    Text(AppText.pick(configurationStore.config.language, english: "Current version", japanese: "現在のバージョン", chinese: "当前版本") + " \(UpdateChecker.currentVersion)")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Toggle(AppText.pick(configurationStore.config.language, english: "Check at launch", japanese: "起動時に確認", chinese: "启动时自动检查"), isOn: $autoCheckUpdates)
+                        .font(.system(size: 12, weight: .medium))
+                    Button(checkTitle, action: check)
+                        .disabled(state == .checking)
+                        .accessibilityIdentifier("settings.updates.check")
+                }
+                statusRow
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var statusRow: some View {
+        switch state {
+        case .idle:
+            EmptyView()
+        case .checking:
+            MessageRow(
+                icon: "arrow.triangle.2.circlepath",
+                title: AppText.pick(configurationStore.config.language, english: "Checking…", japanese: "確認中…", chinese: "正在检查…"),
+                detail: "",
+                color: .gray
+            )
+        case .upToDate(let current):
+            MessageRow(
+                icon: "checkmark.circle.fill",
+                title: AppText.pick(configurationStore.config.language, english: "Up to date", japanese: "最新です", chinese: "已是最新版本"),
+                detail: current,
+                color: .green
+            )
+        case .available(let release):
+            HStack(spacing: 10) {
+                MessageRow(
+                    icon: "sparkles",
+                    title: AppText.pick(configurationStore.config.language, english: "New version \(release.version)", japanese: "新しいバージョン \(release.version)", chinese: "发现新版本 \(release.version)"),
+                    detail: "",
+                    color: .blue
+                )
+                Button(AppText.pick(configurationStore.config.language, english: "Open download page", japanese: "ダウンロードページを開く", chinese: "前往下载")) {
+                    NSWorkspace.shared.open(release.pageURL)
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        case .failed(let message):
+            MessageRow(
+                icon: "exclamationmark.triangle",
+                title: AppText.pick(configurationStore.config.language, english: "Check failed", japanese: "確認に失敗しました", chinese: "检查失败"),
+                detail: message,
+                color: .orange
+            )
+        }
+    }
+
+    private var checkTitle: String {
+        AppText.pick(configurationStore.config.language, english: "Check for updates", japanese: "アップデートを確認", chinese: "检查更新")
     }
 }
 

--- a/Sources/VibelslandFree/UpdateChecker.swift
+++ b/Sources/VibelslandFree/UpdateChecker.swift
@@ -1,0 +1,56 @@
+import Foundation
+import VibelslandFreeCore
+
+enum UpdateCheckState: Equatable {
+    case idle
+    case checking
+    case upToDate(current: String)
+    case available(RemoteRelease)
+    case failed(message: String)
+}
+
+/// 更新检查的网络调用。只在用户手动触发或显式开启自动检查时被调用，
+/// 与「核心功能零网络」的本地优先承诺不冲突。
+struct UpdateChecker {
+    var session: URLSession = {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 10
+        configuration.timeoutIntervalForResource = 15
+        return URLSession(configuration: configuration)
+    }()
+
+    static var currentVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+    }
+
+    func fetchLatestRelease() async -> Result<RemoteRelease, Error> {
+        var request = URLRequest(url: UpdateCheckPolicy.latestReleaseAPIURL)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        do {
+            let (data, response) = try await session.data(for: request)
+            if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+                return .failure(UpdateCheckError.badStatus(http.statusCode))
+            }
+            guard let release = UpdateCheckPolicy.parseRelease(from: data) else {
+                return .failure(UpdateCheckError.unparseableResponse)
+            }
+            return .success(release)
+        } catch {
+            return .failure(error)
+        }
+    }
+}
+
+enum UpdateCheckError: Error, LocalizedError {
+    case badStatus(Int)
+    case unparseableResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .badStatus(let code):
+            "HTTP \(code)"
+        case .unparseableResponse:
+            "unexpected response format"
+        }
+    }
+}

--- a/Sources/VibelslandFreeCore/AppConfiguration.swift
+++ b/Sources/VibelslandFreeCore/AppConfiguration.swift
@@ -49,6 +49,7 @@ package struct AppConfiguration: Codable, Equatable {
     package var maxVisibleSessions: Int
     package var enableGlobalHotKeys: Bool
     package var enableApprovalNotifications: Bool
+    package var autoCheckUpdates: Bool
 
     package static let `default` = AppConfiguration(
         enableClaude: true,
@@ -63,7 +64,8 @@ package struct AppConfiguration: Codable, Equatable {
         approvalTimeoutSeconds: 7_200,
         maxVisibleSessions: 5,
         enableGlobalHotKeys: false,
-        enableApprovalNotifications: false
+        enableApprovalNotifications: false,
+        autoCheckUpdates: false
     )
 
     package enum CodingKeys: String, CodingKey {
@@ -80,6 +82,7 @@ package struct AppConfiguration: Codable, Equatable {
         case maxVisibleSessions
         case enableGlobalHotKeys
         case enableApprovalNotifications
+        case autoCheckUpdates
     }
 
     package init(
@@ -95,7 +98,8 @@ package struct AppConfiguration: Codable, Equatable {
         approvalTimeoutSeconds: TimeInterval,
         maxVisibleSessions: Int,
         enableGlobalHotKeys: Bool = false,
-        enableApprovalNotifications: Bool = false
+        enableApprovalNotifications: Bool = false,
+        autoCheckUpdates: Bool = false
     ) {
         self.enableClaude = enableClaude
         self.enableCodexCLI = enableCodexCLI
@@ -110,6 +114,7 @@ package struct AppConfiguration: Codable, Equatable {
         self.maxVisibleSessions = maxVisibleSessions
         self.enableGlobalHotKeys = enableGlobalHotKeys
         self.enableApprovalNotifications = enableApprovalNotifications
+        self.autoCheckUpdates = autoCheckUpdates
     }
 
     package init(from decoder: Decoder) throws {
@@ -127,6 +132,7 @@ package struct AppConfiguration: Codable, Equatable {
         maxVisibleSessions = try container.decodeIfPresent(Int.self, forKey: .maxVisibleSessions) ?? Self.default.maxVisibleSessions
         enableGlobalHotKeys = try container.decodeIfPresent(Bool.self, forKey: .enableGlobalHotKeys) ?? Self.default.enableGlobalHotKeys
         enableApprovalNotifications = try container.decodeIfPresent(Bool.self, forKey: .enableApprovalNotifications) ?? Self.default.enableApprovalNotifications
+        autoCheckUpdates = try container.decodeIfPresent(Bool.self, forKey: .autoCheckUpdates) ?? Self.default.autoCheckUpdates
     }
 }
 

--- a/Sources/VibelslandFreeCore/UpdateCheckPolicy.swift
+++ b/Sources/VibelslandFreeCore/UpdateCheckPolicy.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+package struct RemoteRelease: Equatable {
+    package var version: String
+    package var pageURL: URL
+
+    package init(version: String, pageURL: URL) {
+        self.version = version
+        self.pageURL = pageURL
+    }
+}
+
+/// 更新检查的纯逻辑：接口地址、GitHub Release JSON 解析、版本比较。
+/// 网络请求留在界面层；本地优先承诺由调用方保证——仅在用户手动点击
+/// 或显式开启自动检查时才发起请求。
+package enum UpdateCheckPolicy {
+    package static let latestReleaseAPIURL = URL(string: "https://api.github.com/repos/shinteni/prompt-island/releases/latest")!
+    package static let releasesPageURL = URL(string: "https://github.com/shinteni/prompt-island/releases")!
+
+    /// 从 GitHub `releases/latest` 响应中取 tag 与发布页。
+    package static func parseRelease(from data: Data) -> RemoteRelease? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let tag = object["tag_name"] as? String else {
+            return nil
+        }
+        let version = normalizedVersion(tag)
+        guard !version.isEmpty else { return nil }
+        let pageURL = (object["html_url"] as? String).flatMap(URL.init(string:)) ?? releasesPageURL
+        return RemoteRelease(version: version, pageURL: pageURL)
+    }
+
+    /// 去掉前导 v/V 与空白："v0.2.0" -> "0.2.0"。
+    package static func normalizedVersion(_ raw: String) -> String {
+        var value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.lowercased().hasPrefix("v") {
+            value = String(value.dropFirst())
+        }
+        return value
+    }
+
+    /// 点分数字比较；分段缺失按 0。任一版本含非数字分段（如预发布后缀）
+    /// 时整体保守视为不更新——必须先整体校验，逐段校验会在遇到非数字段
+    /// 之前就因高位分段差异提前返回。
+    package static func isNewer(remote: String, current: String) -> Bool {
+        guard let remoteValues = numericParts(normalizedVersion(remote)),
+              let currentValues = numericParts(normalizedVersion(current)) else {
+            return false
+        }
+        let count = max(remoteValues.count, currentValues.count)
+        for index in 0..<count {
+            let remoteValue = index < remoteValues.count ? remoteValues[index] : 0
+            let currentValue = index < currentValues.count ? currentValues[index] : 0
+            if remoteValue != currentValue {
+                return remoteValue > currentValue
+            }
+        }
+        return false
+    }
+
+    private static func numericParts(_ value: String) -> [Int]? {
+        guard !value.isEmpty else { return nil }
+        var result: [Int] = []
+        for part in value.split(separator: ".") {
+            guard let number = Int(part) else { return nil }
+            result.append(number)
+        }
+        return result.isEmpty ? nil : result
+    }
+}

--- a/Tests/VibelslandFreeCoreTests/UpdateCheckPolicyTests.swift
+++ b/Tests/VibelslandFreeCoreTests/UpdateCheckPolicyTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import VibelslandFreeCore
+
+@Suite
+struct UpdateCheckPolicyTests {
+    @Test func testVersionComparisonMatrix() {
+        XCTAssertTrue(UpdateCheckPolicy.isNewer(remote: "0.2.0", current: "0.1.0"), "Minor bump is newer")
+        XCTAssertTrue(UpdateCheckPolicy.isNewer(remote: "1.0.0", current: "0.9.9"), "Major bump is newer")
+        XCTAssertTrue(UpdateCheckPolicy.isNewer(remote: "0.1.1", current: "0.1.0"), "Patch bump is newer")
+        XCTAssertTrue(UpdateCheckPolicy.isNewer(remote: "0.1.0.1", current: "0.1.0"), "Extra segment counts")
+        XCTAssertTrue(UpdateCheckPolicy.isNewer(remote: "v0.2.0", current: "0.1.0"), "v prefix normalizes")
+
+        XCTAssertFalse(UpdateCheckPolicy.isNewer(remote: "0.1.0", current: "0.1.0"), "Same version is not newer")
+        XCTAssertFalse(UpdateCheckPolicy.isNewer(remote: "0.1.0", current: "0.2.0"), "Older is not newer")
+        XCTAssertFalse(UpdateCheckPolicy.isNewer(remote: "0.1", current: "0.1.0"), "Missing segment pads to zero")
+        XCTAssertFalse(UpdateCheckPolicy.isNewer(remote: "0.2.0-beta", current: "0.1.0"), "Non-numeric segments stay conservative")
+        XCTAssertFalse(UpdateCheckPolicy.isNewer(remote: "", current: "0.1.0"), "Empty remote is not newer")
+    }
+
+    @Test func testNormalizedVersionStripsPrefix() {
+        XCTAssertEqual(UpdateCheckPolicy.normalizedVersion("v0.1.0"), "0.1.0", "Lowercase v strips")
+        XCTAssertEqual(UpdateCheckPolicy.normalizedVersion("V2.0"), "2.0", "Uppercase V strips")
+        XCTAssertEqual(UpdateCheckPolicy.normalizedVersion(" 0.1.0 "), "0.1.0", "Whitespace trims")
+    }
+
+    @Test func testParseReleaseFromGitHubJSON() throws {
+        let json = """
+        {
+          "tag_name": "v0.2.0",
+          "html_url": "https://github.com/shinteni/prompt-island/releases/tag/v0.2.0",
+          "name": "Vibelsland Free 0.2.0"
+        }
+        """.data(using: .utf8)!
+        let release = UpdateCheckPolicy.parseRelease(from: json)
+        XCTAssertEqual(release?.version, "0.2.0", "Tag parses without the v prefix")
+        XCTAssertEqual(
+            release?.pageURL.absoluteString,
+            "https://github.com/shinteni/prompt-island/releases/tag/v0.2.0",
+            "Release page URL parses"
+        )
+    }
+
+    @Test func testParseReleaseFallbacksAndFailures() {
+        let missingURL = """
+        {"tag_name": "0.3.0"}
+        """.data(using: .utf8)!
+        XCTAssertEqual(
+            UpdateCheckPolicy.parseRelease(from: missingURL)?.pageURL,
+            UpdateCheckPolicy.releasesPageURL,
+            "Missing html_url falls back to the releases page"
+        )
+
+        XCTAssertTrue(
+            UpdateCheckPolicy.parseRelease(from: Data("not json".utf8)) == nil,
+            "Malformed payloads parse to nil"
+        )
+        XCTAssertTrue(
+            UpdateCheckPolicy.parseRelease(from: Data("{}".utf8)) == nil,
+            "Payloads without tag_name parse to nil"
+        )
+        XCTAssertTrue(
+            UpdateCheckPolicy.parseRelease(from: Data(#"{"tag_name": "v"}"#.utf8)) == nil,
+            "Empty version after normalization parses to nil"
+        )
+    }
+
+    @Test func testAutoCheckDefaultsToDisabledAndDecodesLegacyConfig() throws {
+        XCTAssertFalse(AppConfiguration.default.autoCheckUpdates, "Auto update check is opt-in")
+
+        let legacyConfig = """
+        {
+          "enableClaude": true,
+          "enableCodexCLI": true,
+          "enableCodexDesktop": true,
+          "enableSounds": true,
+          "soundTheme": "soft",
+          "doNotDisturb": false,
+          "launchAtLogin": false,
+          "islandPosition": "topCenter",
+          "approvalTimeoutSeconds": 7200,
+          "maxVisibleSessions": 5
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AppConfiguration.self, from: legacyConfig)
+        XCTAssertFalse(decoded.autoCheckUpdates, "Legacy configs without the key stay disabled")
+    }
+}


### PR DESCRIPTION
## 概要

设置页新增「更新」卡片：手动**检查更新**按钮 + 默认关闭的启动时自动检查；发现新版本时展示版本号和发布页链接。

## 本地优先承诺

只在用户主动点击或显式开启自动检查时访问 GitHub Releases API，不携带任何账号/会话/遥测数据。PRIVACY.md 的 Network 章节已如实补充。

## 实现与修复

- 版本解析/比较在 `UpdateCheckPolicy`（可单测）。
- 比较器**先整体校验所有分段为数字**再逐段比较——修复了逐段校验会在遇到非数字段前因高位差异提前返回、导致 `0.2.0-beta` 被误报为新版本的 bug（由独立进程断言发现）。

## 验证

- 独立进程断言 11 项全过（含双位数字非字典序比较）。
- 真实 GitHub API 响应（v0.1.0）与解析器格式吻合。

## 合并顺序

堆叠 PR 链第 **4/6** 个，base 为 `feat/approval-queue`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)