### PR TITLE
feat: add Claude Code token usage and estimated cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 
+- Added Claude Code token usage to session details: per-turn and cumulative token counts parsed incrementally from local transcripts, plus an estimated API-equivalent cost for recognized model families.
 - Added an update checker in settings: a manual "Check for updates" button plus an optional launch-time check (off by default); the GitHub releases API is contacted only on explicit user action, keeping the local-first promise.
 - Added an approval queue in the expanded island: when several tools wait at once, approvals are listed oldest-first with inline Allow/Decline per row, an overflow count, and a pending-approval count on the compact pill.
 - Added optional approval notifications: macOS Notification Center banners with Allow/Decline actions as a fallback when you are away from the island (off by default, withdrawn once the approval resolves, suppressed by Do Not Disturb).

--- a/Sources/VibelslandFree/IslandDetailViews.swift
+++ b/Sources/VibelslandFree/IslandDetailViews.swift
@@ -137,7 +137,12 @@ struct UsageStrip: View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
                 UsageMetric(title: AppText.pick(configurationStore.config.language, english: "Turn", japanese: "今回", chinese: "本轮"), value: UsageSnapshot.compactNumber(usage.lastTokens))
-                UsageMetric(title: AppText.pick(configurationStore.config.language, english: "Total", japanese: "合計", chinese: "总计"), value: usage.totalText)
+                if usage.totalTokens > 0 {
+                    UsageMetric(title: AppText.pick(configurationStore.config.language, english: "Total", japanese: "合計", chinese: "总计"), value: usage.totalText)
+                }
+                if let cost = usage.estimatedCostUSD {
+                    UsageMetric(title: AppText.pick(configurationStore.config.language, english: "Est.", japanese: "概算", chinese: "估算"), value: UsageSnapshot.costText(cost))
+                }
                 if usage.contextWindow > 0 {
                     UsageMetric(title: AppText.pick(configurationStore.config.language, english: "Context", japanese: "コンテキスト", chinese: "上下文"), value: UsageSnapshot.compactNumber(usage.contextWindow))
                 }

--- a/Sources/VibelslandFreeCore/ClaudeUsagePolicy.swift
+++ b/Sources/VibelslandFreeCore/ClaudeUsagePolicy.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+package struct ClaudeTurnUsage: Equatable {
+    package var inputTokens: Int
+    package var outputTokens: Int
+    package var cacheWriteTokens: Int
+    package var cacheReadTokens: Int
+    package var model: String?
+
+    package init(
+        inputTokens: Int,
+        outputTokens: Int,
+        cacheWriteTokens: Int,
+        cacheReadTokens: Int,
+        model: String?
+    ) {
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.cacheWriteTokens = cacheWriteTokens
+        self.cacheReadTokens = cacheReadTokens
+        self.model = model
+    }
+
+    package var totalTokens: Int {
+        inputTokens + outputTokens + cacheWriteTokens + cacheReadTokens
+    }
+}
+
+package struct ClaudeUsageAggregate: Equatable {
+    package var inputTokens = 0
+    package var outputTokens = 0
+    package var cacheWriteTokens = 0
+    package var cacheReadTokens = 0
+    package var turns = 0
+    package var lastTurnTokens = 0
+    package var model: String?
+
+    package init() {}
+
+    package mutating func add(_ turn: ClaudeTurnUsage) {
+        inputTokens += turn.inputTokens
+        outputTokens += turn.outputTokens
+        cacheWriteTokens += turn.cacheWriteTokens
+        cacheReadTokens += turn.cacheReadTokens
+        turns += 1
+        lastTurnTokens = turn.totalTokens
+        if let model = turn.model, !model.isEmpty {
+            self.model = model
+        }
+    }
+
+    package var totalTokens: Int {
+        inputTokens + outputTokens + cacheWriteTokens + cacheReadTokens
+    }
+
+    package var estimatedCostUSD: Double? {
+        ClaudeUsagePolicy.costUSD(
+            inputTokens: inputTokens,
+            outputTokens: outputTokens,
+            cacheWriteTokens: cacheWriteTokens,
+            cacheReadTokens: cacheReadTokens,
+            model: model
+        )
+    }
+}
+
+/// Claude Code transcript 的 token 用量解析与成本估算。
+/// Codex 的 rollout 自带累计 token_count 事件，Claude transcript 只有每条
+/// assistant 消息的 message.usage，所以这里按回合累加。
+package enum ClaudeUsagePolicy {
+    /// 按模型家族的 API 牌价估算（美元 / 百万 token）。订阅计划下没有边际
+    /// 成本，这个数字只用于展示「等价 API 成本」的量级，所以精确到家族即可；
+    /// 未识别的模型不给估算。缓存写按输入价 1.25 倍、缓存读按 0.1 倍计。
+    package static func rates(forModel model: String?) -> (input: Double, output: Double)? {
+        guard let model = model?.lowercased() else { return nil }
+        if model.contains("opus") {
+            return (15, 75)
+        }
+        if model.contains("sonnet") {
+            return (3, 15)
+        }
+        if model.contains("haiku") {
+            return (1, 5)
+        }
+        return nil
+    }
+
+    package static func costUSD(
+        inputTokens: Int,
+        outputTokens: Int,
+        cacheWriteTokens: Int,
+        cacheReadTokens: Int,
+        model: String?
+    ) -> Double? {
+        guard let rates = rates(forModel: model) else { return nil }
+        let perToken = 1.0 / 1_000_000
+        let input = Double(inputTokens) * rates.input * perToken
+        let output = Double(outputTokens) * rates.output * perToken
+        let cacheWrite = Double(cacheWriteTokens) * rates.input * 1.25 * perToken
+        let cacheRead = Double(cacheReadTokens) * rates.input * 0.1 * perToken
+        return input + output + cacheWrite + cacheRead
+    }
+
+    /// 从 transcript 的一行 JSON 对象里解析一次 assistant 回合的用量。
+    package static func parseTurn(from object: [String: Any]) -> ClaudeTurnUsage? {
+        guard object["type"] as? String == "assistant",
+              let message = object["message"] as? [String: Any],
+              let usage = message["usage"] as? [String: Any] else {
+            return nil
+        }
+        let turn = ClaudeTurnUsage(
+            inputTokens: intValue(usage["input_tokens"]),
+            outputTokens: intValue(usage["output_tokens"]),
+            cacheWriteTokens: intValue(usage["cache_creation_input_tokens"]),
+            cacheReadTokens: intValue(usage["cache_read_input_tokens"]),
+            model: message["model"] as? String
+        )
+        return turn.totalTokens > 0 ? turn : nil
+    }
+
+    package static func usageSnapshot(from aggregate: ClaudeUsageAggregate) -> UsageSnapshot? {
+        guard aggregate.turns > 0 else { return nil }
+        return UsageSnapshot(
+            lastTokens: aggregate.lastTurnTokens,
+            totalTokens: aggregate.totalTokens,
+            contextWindow: 0,
+            estimatedCostUSD: aggregate.estimatedCostUSD
+        )
+    }
+
+    private static func intValue(_ value: Any?) -> Int {
+        switch value {
+        case let value as Int:
+            return value
+        case let value as NSNumber:
+            return value.intValue
+        default:
+            return 0
+        }
+    }
+}

--- a/Sources/VibelslandFreeCore/ConversationTranscriptReader.swift
+++ b/Sources/VibelslandFreeCore/ConversationTranscriptReader.swift
@@ -7,6 +7,18 @@ package final class ConversationTranscriptReader: @unchecked Sendable {
     private let tailLineLimit = SessionMemoryPolicy.transcriptTailLineLimit
     private let dateParser = ISO8601Parser()
 
+    /// Claude 用量按文件增量累加：记录已解析到的字节位置，事件到来时只读
+    /// 追加部分。首次遇到超大文件时只回溯尾部一段，保证读取始终有界。
+    private struct ClaudeUsageCacheEntry {
+        var parsedBytes: UInt64
+        var aggregate: ClaudeUsageAggregate
+    }
+
+    private static let claudeUsageInitialScanBytes: UInt64 = 10 * 1024 * 1024
+    private static let claudeUsageMarker = Data("\"usage\"".utf8)
+    private let usageCacheLock = NSLock()
+    private var claudeUsageCache: [String: ClaudeUsageCacheEntry] = [:]
+
     package init(fileManager: FileManager = .default, homeURL: URL = AppPaths.home) {
         self.fileManager = fileManager
         self.homeURL = homeURL
@@ -63,6 +75,12 @@ package final class ConversationTranscriptReader: @unchecked Sendable {
             }
         }
 
+        if source == .claudeCode,
+           let aggregate = claudeUsageAggregate(for: url),
+           let snapshot = ClaudeUsagePolicy.usageSnapshot(from: aggregate) {
+            usage = snapshot
+        }
+
         return AgentTranscriptSnapshot(
             activities: Array(transcriptActivities.suffix(limit)),
             usage: usage,
@@ -72,6 +90,83 @@ package final class ConversationTranscriptReader: @unchecked Sendable {
             completedAt: completedAt,
             latestActiveAt: latestActiveAt
         )
+    }
+
+    package func claudeUsageAggregate(for url: URL) -> ClaudeUsageAggregate? {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+              let size = (attributes[.size] as? NSNumber)?.uint64Value else {
+            return nil
+        }
+
+        usageCacheLock.lock()
+        var entry = claudeUsageCache[url.path]
+        usageCacheLock.unlock()
+
+        // 文件被截断或轮转时重来。
+        if let cached = entry, cached.parsedBytes > size {
+            entry = nil
+        }
+        if let cached = entry, cached.parsedBytes == size {
+            return cached.aggregate
+        }
+
+        var aggregate = entry?.aggregate ?? ClaudeUsageAggregate()
+        var offset = entry?.parsedBytes ?? 0
+        var skipsPartialFirstLine = false
+        // 无缓存且文件太大时，只回溯尾部一段；增量意外过大时同样重置回溯，
+        // 保证单次读取有界。
+        if size - offset > Self.claudeUsageInitialScanBytes {
+            aggregate = ClaudeUsageAggregate()
+            offset = size - Self.claudeUsageInitialScanBytes
+            skipsPartialFirstLine = true
+        }
+
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        guard (try? handle.seek(toOffset: offset)) != nil,
+              let data = try? handle.readToEnd(), !data.isEmpty else {
+            return aggregate.turns > 0 ? aggregate : nil
+        }
+
+        var body = data
+        if skipsPartialFirstLine {
+            if let firstNewline = body.firstIndex(of: 0x0A) {
+                let dropped = body.distance(from: body.startIndex, to: firstNewline) + 1
+                offset += UInt64(dropped)
+                body = body[body.index(after: firstNewline)...]
+            } else {
+                return aggregate.turns > 0 ? aggregate : nil
+            }
+        }
+
+        // 只消费到最后一个完整行，写到一半的行留给下次。
+        guard let lastNewline = body.lastIndex(of: 0x0A) else {
+            storeClaudeUsage(ClaudeUsageCacheEntry(parsedBytes: offset, aggregate: aggregate), for: url.path)
+            return aggregate.turns > 0 ? aggregate : nil
+        }
+        let complete = body[body.startIndex...lastNewline]
+        let consumedBytes = UInt64(complete.count)
+
+        for line in complete.split(separator: 0x0A) {
+            guard line.range(of: Self.claudeUsageMarker) != nil,
+                  let object = try? JSONSerialization.jsonObject(with: Data(line)) as? [String: Any],
+                  let turn = ClaudeUsagePolicy.parseTurn(from: object) else {
+                continue
+            }
+            aggregate.add(turn)
+        }
+
+        storeClaudeUsage(
+            ClaudeUsageCacheEntry(parsedBytes: offset + consumedBytes, aggregate: aggregate),
+            for: url.path
+        )
+        return aggregate.turns > 0 ? aggregate : nil
+    }
+
+    private func storeClaudeUsage(_ entry: ClaudeUsageCacheEntry, for path: String) {
+        usageCacheLock.lock()
+        claudeUsageCache[path] = entry
+        usageCacheLock.unlock()
     }
 
     private func transcriptURLs(for event: AgentEvent) -> [URL] {

--- a/Sources/VibelslandFreeCore/Models.swift
+++ b/Sources/VibelslandFreeCore/Models.swift
@@ -378,6 +378,7 @@ package struct UsageSnapshot: Equatable {
     package var secondaryResetsAt: Date?
     package var planType: String?
     package var limitName: String?
+    package var estimatedCostUSD: Double?
 
     package init(
         lastTokens: Int,
@@ -390,7 +391,8 @@ package struct UsageSnapshot: Equatable {
         primaryResetsAt: Date? = nil,
         secondaryResetsAt: Date? = nil,
         planType: String? = nil,
-        limitName: String? = nil
+        limitName: String? = nil,
+        estimatedCostUSD: Double? = nil
     ) {
         self.lastTokens = lastTokens
         self.totalTokens = totalTokens
@@ -403,6 +405,7 @@ package struct UsageSnapshot: Equatable {
         self.secondaryResetsAt = secondaryResetsAt
         self.planType = planType
         self.limitName = limitName
+        self.estimatedCostUSD = estimatedCostUSD
     }
 
     package var shortText: String {
@@ -441,6 +444,11 @@ package struct UsageSnapshot: Equatable {
 
     package static func percent(_ value: Double) -> String {
         "\(Int(value.rounded()))%"
+    }
+
+    package static func costText(_ value: Double) -> String {
+        guard value >= 0.01 else { return "<$0.01" }
+        return String(format: "$%.2f", value)
     }
 
     package static func compactNumber(_ value: Int) -> String {

--- a/Tests/VibelslandFreeCoreTests/ClaudeUsagePolicyTests.swift
+++ b/Tests/VibelslandFreeCoreTests/ClaudeUsagePolicyTests.swift
@@ -25,17 +25,18 @@ struct ClaudeUsagePolicyTests {
     }
 
     @Test func testCostEstimatesPerModelFamily() {
+        // 浮点乘除有舍入误差（如 1e6 × 1 × 0.1 / 1e6 = 0.09999…），成本断言一律用容差比较。
         let opus = ClaudeUsagePolicy.costUSD(inputTokens: 1_000_000, outputTokens: 0, cacheWriteTokens: 0, cacheReadTokens: 0, model: "claude-opus-4")
-        XCTAssertEqual(opus ?? 0, 15.0, "Opus input rate is 15 per MTok")
+        XCTAssertTrue(abs((opus ?? 0) - 15.0) < 1e-9, "Opus input rate is 15 per MTok")
 
         let sonnetOutput = ClaudeUsagePolicy.costUSD(inputTokens: 0, outputTokens: 1_000_000, cacheWriteTokens: 0, cacheReadTokens: 0, model: "claude-sonnet-4-5")
-        XCTAssertEqual(sonnetOutput ?? 0, 15.0, "Sonnet output rate is 15 per MTok")
+        XCTAssertTrue(abs((sonnetOutput ?? 0) - 15.0) < 1e-9, "Sonnet output rate is 15 per MTok")
 
         let haikuCacheRead = ClaudeUsagePolicy.costUSD(inputTokens: 0, outputTokens: 0, cacheWriteTokens: 0, cacheReadTokens: 1_000_000, model: "claude-haiku-4-5")
-        XCTAssertEqual(haikuCacheRead ?? 0, 0.1, "Cache reads bill at a tenth of the input rate")
+        XCTAssertTrue(abs((haikuCacheRead ?? 0) - 0.1) < 1e-9, "Cache reads bill at a tenth of the input rate")
 
         let sonnetCacheWrite = ClaudeUsagePolicy.costUSD(inputTokens: 0, outputTokens: 0, cacheWriteTokens: 1_000_000, cacheReadTokens: 0, model: "claude-sonnet-4-5")
-        XCTAssertEqual(sonnetCacheWrite ?? 0, 3.75, "Cache writes bill at 1.25x the input rate")
+        XCTAssertTrue(abs((sonnetCacheWrite ?? 0) - 3.75) < 1e-9, "Cache writes bill at 1.25x the input rate")
 
         XCTAssertTrue(
             ClaudeUsagePolicy.costUSD(inputTokens: 100, outputTokens: 100, cacheWriteTokens: 0, cacheReadTokens: 0, model: "unknown-model") == nil,

--- a/Tests/VibelslandFreeCoreTests/ClaudeUsagePolicyTests.swift
+++ b/Tests/VibelslandFreeCoreTests/ClaudeUsagePolicyTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+@testable import VibelslandFreeCore
+
+@Suite
+struct ClaudeUsagePolicyTests {
+    @Test func testParseTurnFromAssistantLine() throws {
+        let object = try line(input: 1_000, output: 200, cacheWrite: 300, cacheRead: 5_000, model: "claude-sonnet-4-5")
+        let turn = ClaudeUsagePolicy.parseTurn(from: object)
+        XCTAssertEqual(turn?.inputTokens, 1_000, "Input tokens parse")
+        XCTAssertEqual(turn?.outputTokens, 200, "Output tokens parse")
+        XCTAssertEqual(turn?.cacheWriteTokens, 300, "Cache write tokens parse")
+        XCTAssertEqual(turn?.cacheReadTokens, 5_000, "Cache read tokens parse")
+        XCTAssertEqual(turn?.model, "claude-sonnet-4-5", "Model parses")
+        XCTAssertEqual(turn?.totalTokens, 6_500, "Total sums every bucket")
+    }
+
+    @Test func testParseTurnRejectsNonAssistantAndEmptyUsage() throws {
+        var userLine = try line(input: 10, output: 10, cacheWrite: 0, cacheRead: 0, model: "claude-sonnet-4-5")
+        userLine["type"] = "user"
+        XCTAssertTrue(ClaudeUsagePolicy.parseTurn(from: userLine) == nil, "User lines never parse as turns")
+
+        let zero = try line(input: 0, output: 0, cacheWrite: 0, cacheRead: 0, model: "claude-sonnet-4-5")
+        XCTAssertTrue(ClaudeUsagePolicy.parseTurn(from: zero) == nil, "Zero usage parses to nil")
+    }
+
+    @Test func testCostEstimatesPerModelFamily() {
+        let opus = ClaudeUsagePolicy.costUSD(inputTokens: 1_000_000, outputTokens: 0, cacheWriteTokens: 0, cacheReadTokens: 0, model: "claude-opus-4")
+        XCTAssertEqual(opus ?? 0, 15.0, "Opus input rate is 15 per MTok")
+
+        let sonnetOutput = ClaudeUsagePolicy.costUSD(inputTokens: 0, outputTokens: 1_000_000, cacheWriteTokens: 0, cacheReadTokens: 0, model: "claude-sonnet-4-5")
+        XCTAssertEqual(sonnetOutput ?? 0, 15.0, "Sonnet output rate is 15 per MTok")
+
+        let haikuCacheRead = ClaudeUsagePolicy.costUSD(inputTokens: 0, outputTokens: 0, cacheWriteTokens: 0, cacheReadTokens: 1_000_000, model: "claude-haiku-4-5")
+        XCTAssertEqual(haikuCacheRead ?? 0, 0.1, "Cache reads bill at a tenth of the input rate")
+
+        let sonnetCacheWrite = ClaudeUsagePolicy.costUSD(inputTokens: 0, outputTokens: 0, cacheWriteTokens: 1_000_000, cacheReadTokens: 0, model: "claude-sonnet-4-5")
+        XCTAssertEqual(sonnetCacheWrite ?? 0, 3.75, "Cache writes bill at 1.25x the input rate")
+
+        XCTAssertTrue(
+            ClaudeUsagePolicy.costUSD(inputTokens: 100, outputTokens: 100, cacheWriteTokens: 0, cacheReadTokens: 0, model: "unknown-model") == nil,
+            "Unknown models produce no estimate"
+        )
+        XCTAssertTrue(
+            ClaudeUsagePolicy.costUSD(inputTokens: 100, outputTokens: 100, cacheWriteTokens: 0, cacheReadTokens: 0, model: nil) == nil,
+            "Missing model produces no estimate"
+        )
+    }
+
+    @Test func testAggregateAccumulatesAndMapsToSnapshot() throws {
+        var aggregate = ClaudeUsageAggregate()
+        XCTAssertTrue(ClaudeUsagePolicy.usageSnapshot(from: aggregate) == nil, "Empty aggregate maps to nil")
+
+        aggregate.add(ClaudeTurnUsage(inputTokens: 100, outputTokens: 50, cacheWriteTokens: 10, cacheReadTokens: 40, model: "claude-sonnet-4-5"))
+        aggregate.add(ClaudeTurnUsage(inputTokens: 200, outputTokens: 100, cacheWriteTokens: 0, cacheReadTokens: 300, model: nil))
+
+        XCTAssertEqual(aggregate.turns, 2, "Turn count accumulates")
+        XCTAssertEqual(aggregate.totalTokens, 800, "Totals accumulate across turns")
+        XCTAssertEqual(aggregate.lastTurnTokens, 600, "Last turn reflects the newest usage")
+        XCTAssertEqual(aggregate.model, "claude-sonnet-4-5", "Model sticks once seen")
+
+        let snapshot = ClaudeUsagePolicy.usageSnapshot(from: aggregate)
+        XCTAssertEqual(snapshot?.lastTokens, 600, "Snapshot last tokens map")
+        XCTAssertEqual(snapshot?.totalTokens, 800, "Snapshot totals map")
+        XCTAssertTrue(snapshot?.estimatedCostUSD != nil, "Known model yields a cost estimate")
+    }
+
+    @Test func testCostTextFormatting() {
+        XCTAssertEqual(UsageSnapshot.costText(0.005), "<$0.01", "Tiny costs floor to <$0.01")
+        XCTAssertEqual(UsageSnapshot.costText(0.42), "$0.42", "Cents format to two places")
+        XCTAssertEqual(UsageSnapshot.costText(12.3456), "$12.35", "Dollars round to two places")
+    }
+
+    @Test func testReaderAggregatesIncrementally() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vibelsland-usage-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let transcript = directory.appendingPathComponent("session.jsonl")
+
+        let reader = ConversationTranscriptReader(homeURL: directory)
+        try assistantLine(input: 100, output: 50, model: "claude-sonnet-4-5")
+            .write(to: transcript, atomically: true, encoding: .utf8)
+
+        let first = reader.claudeUsageAggregate(for: transcript)
+        XCTAssertEqual(first?.turns, 1, "First scan finds the first turn")
+        XCTAssertEqual(first?.totalTokens, 150, "First scan sums the first turn")
+
+        let handle = try FileHandle(forWritingTo: transcript)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(assistantLine(input: 200, output: 100, model: "claude-sonnet-4-5").utf8))
+        try handle.close()
+
+        let second = reader.claudeUsageAggregate(for: transcript)
+        XCTAssertEqual(second?.turns, 2, "Appended turn is picked up incrementally")
+        XCTAssertEqual(second?.totalTokens, 450, "Totals include the appended turn")
+        XCTAssertEqual(second?.lastTurnTokens, 300, "Last turn tracks the appended usage")
+
+        let cached = reader.claudeUsageAggregate(for: transcript)
+        XCTAssertEqual(cached?.totalTokens, 450, "Unchanged files return the cached aggregate")
+    }
+
+    private func assistantLine(input: Int, output: Int, model: String) -> String {
+        "{\"type\":\"assistant\",\"timestamp\":\"2026-07-04T00:00:00Z\",\"message\":{\"model\":\"\(model)\",\"usage\":{\"input_tokens\":\(input),\"output_tokens\":\(output),\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0},\"content\":[]}}\n"
+    }
+
+    private func line(input: Int, output: Int, cacheWrite: Int, cacheRead: Int, model: String) throws -> [String: Any] {
+        let json = """
+        {
+          "type": "assistant",
+          "message": {
+            "model": "\(model)",
+            "usage": {
+              "input_tokens": \(input),
+              "output_tokens": \(output),
+              "cache_creation_input_tokens": \(cacheWrite),
+              "cache_read_input_tokens": \(cacheRead)
+            }
+          }
+        }
+        """.data(using: .utf8)!
+        return try JSONSerialization.jsonObject(with: json) as! [String: Any]
+    }
+}


### PR DESCRIPTION
## 概要

Claude Code 会话此前完全没有 token 统计（`usageSnapshot` 只解析 Codex 的 `token_count` 格式）。本 PR 从 transcript 的 `message.usage` 补齐：**本轮/累计 token + 等价 API 成本估算**。

## 实现

- **增量解析**：按文件记录已解析字节位置，事件到来只读追加的完整行；截断/轮转自动重置；超大文件首扫限定尾部 10MB 窗口——ingest 路径的 IO 始终有界。
- 成本估算识别 opus/sonnet/haiku 家族（含缓存读 0.1×/写 1.25× 系数），未识别模型不给出估算。
- UsageStrip 新增「估算」指标；来源无法提供累计值时隐藏「总计」。

## 验证

- 增量 IO 独立进程 9 项全过：基础聚合、增量追加、缓存命中、**写一半的行不消费**、截断重置、大文件尾部封顶、封顶后仍增量。
- 用本机真实 transcript 验证格式：61 回合 / 2.6M token / `claude-opus-4-6` 正确命中 opus 定价。
- Swift Testing 测试含临时文件端到端增量用例（CI 执行）。

## 合并顺序

堆叠 PR 链第 **5/6** 个，base 为 `feat/update-check`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)