### PR TITLE
perf: replace fixed polling with adaptive and event-driven scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 
+- Reduced background wakeups: the Codex Desktop poller now self-schedules at its adaptive cadence instead of ticking every second, session-aging refresh only wakes at actual visibility boundaries (and not at all when idle and collapsed), and the expanded island's mouse-leave auto-collapse is driven by tracking-area events instead of a 0.22s mouse poll. Refresh rates and collapse timing are unchanged.
 - Added Claude Code token usage to session details: per-turn and cumulative token counts parsed incrementally from local transcripts, plus an estimated API-equivalent cost for recognized model families.
 - Added an update checker in settings: a manual "Check for updates" button plus an optional launch-time check (off by default); the GitHub releases API is contacted only on explicit user action, keeping the local-first promise.
 - Added an approval queue in the expanded island: when several tools wait at once, approvals are listed oldest-first with inline Allow/Decline per row, an overflow count, and a pending-approval count on the compact pill.

--- a/Sources/VibelslandFree/IslandWindow.swift
+++ b/Sources/VibelslandFree/IslandWindow.swift
@@ -8,8 +8,8 @@ final class IslandWindow: NSPanel {
     private var cancellables: Set<AnyCancellable> = []
     private var outsideClickMonitor: Any?
     private var outsideClickArmedAt: Date?
-    private var outsideMouseTimer: Timer?
-    private var outsideMouseTicks = 0
+    private var autoCollapseTimer: Timer?
+    private var autoCollapseWatchActive = false
     private var systemOverviewTriggerMonitor: Any?
     private var systemOverviewDetectionTimer: Timer?
     private var systemOverviewDetectionTicks = 0
@@ -66,6 +66,12 @@ final class IslandWindow: NSPanel {
         hostingView.wantsLayer = true
         hostingView.layer?.backgroundColor = NSColor.clear.cgColor
         contentView = hostingView
+        hostingView.addTrackingArea(NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        ))
 
         observeLayout()
         applyFrame(
@@ -100,7 +106,7 @@ final class IslandWindow: NSPanel {
         if suppressed {
             orderOut(nil)
             stopOutsideClickMonitor()
-            stopOutsideMouseTimer()
+            stopAutoCollapseWatch()
             stopSystemOverviewDetectionTimer()
             stopSystemOverviewTimer()
             stopSystemOverviewEventMonitor()
@@ -285,7 +291,7 @@ final class IslandWindow: NSPanel {
         setFrame(systemOverviewHiddenFrame(), display: false)
         orderOut(nil)
         stopOutsideClickMonitor()
-        stopOutsideMouseTimer()
+        stopAutoCollapseWatch()
     }
 
     private func systemOverviewHiddenFrame() -> NSRect {
@@ -703,19 +709,19 @@ final class IslandWindow: NSPanel {
     private func updateOutsideClickMonitor(expanded: Bool) {
         if hiddenForSystemOverview {
             stopOutsideClickMonitor()
-            stopOutsideMouseTimer()
+            stopAutoCollapseWatch()
             return
         }
         if expanded {
             startOutsideClickMonitor()
             if hasPendingApproval {
-                stopOutsideMouseTimer()
+                stopAutoCollapseWatch()
             } else {
-                startOutsideMouseTimer()
+                startAutoCollapseWatch()
             }
         } else {
             stopOutsideClickMonitor()
-            stopOutsideMouseTimer()
+            stopAutoCollapseWatch()
         }
     }
 
@@ -755,39 +761,52 @@ final class IslandWindow: NSPanel {
         store.isExpanded = false
     }
 
-    private func startOutsideMouseTimer() {
-        guard outsideMouseTimer == nil else { return }
-        outsideMouseTicks = 0
-        outsideMouseTimer = Timer.scheduledTimer(withTimeInterval: 0.22, repeats: true) { [weak self] _ in
+    /// 事件驱动的离开收起：tracking area 的进出事件代替旧的 0.22 秒鼠标轮询。
+    /// 鼠标离开（或启动监视时就在窗外）后启动一次性宽限定时器，重新进入即取消。
+    private func startAutoCollapseWatch() {
+        autoCollapseWatchActive = true
+        if !frame.insetBy(dx: -12, dy: -12).contains(NSEvent.mouseLocation) {
+            armAutoCollapseTimer()
+        }
+    }
+
+    private func stopAutoCollapseWatch() {
+        autoCollapseWatchActive = false
+        autoCollapseTimer?.invalidate()
+        autoCollapseTimer = nil
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        autoCollapseTimer?.invalidate()
+        autoCollapseTimer = nil
+        super.mouseEntered(with: event)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        if autoCollapseWatchActive {
+            armAutoCollapseTimer()
+        }
+        super.mouseExited(with: event)
+    }
+
+    private func armAutoCollapseTimer() {
+        guard autoCollapseWatchActive, store?.isExpanded == true, !hasPendingApproval else { return }
+        autoCollapseTimer?.invalidate()
+        let timer = Timer(timeInterval: IslandAutoCollapsePolicy.graceDuration, repeats: false) { [weak self] _ in
             DispatchQueue.main.async {
-                self?.collapseIfMouseStayedOutside()
+                self?.fireAutoCollapse()
             }
         }
+        RunLoop.main.add(timer, forMode: .common)
+        autoCollapseTimer = timer
     }
 
-    private func stopOutsideMouseTimer() {
-        outsideMouseTimer?.invalidate()
-        outsideMouseTimer = nil
-        outsideMouseTicks = 0
-    }
-
-    private func collapseIfMouseStayedOutside() {
-        guard let store, store.isExpanded else {
-            stopOutsideMouseTimer()
-            return
-        }
-        if hasPendingApproval {
-            stopOutsideMouseTimer()
-            return
-        }
-        if frame.insetBy(dx: -12, dy: -12).contains(NSEvent.mouseLocation) {
-            outsideMouseTicks = 0
-            return
-        }
-        outsideMouseTicks += 1
-        if outsideMouseTicks >= 30 {
-            collapseIfExpanded()
-        }
+    private func fireAutoCollapse() {
+        autoCollapseTimer = nil
+        guard autoCollapseWatchActive, let store, store.isExpanded, !hasPendingApproval else { return }
+        // 窗口动画期间可能漏掉进入事件，收起前再确认鼠标确实在窗外。
+        guard !frame.insetBy(dx: -12, dy: -12).contains(NSEvent.mouseLocation) else { return }
+        collapseIfExpanded()
     }
 
     private var hasPendingApproval: Bool {

--- a/Sources/VibelslandFree/SessionStore+Events.swift
+++ b/Sources/VibelslandFree/SessionStore+Events.swift
@@ -267,15 +267,7 @@ extension SessionStore {
     }
 
     var codexDesktopRefreshInterval: TimeInterval {
-        if isExpanded {
-            return 2.0
-        }
-        let now = Date()
-        let hasRecentOrActiveDesktop = sessions.contains { session in
-            session.source == .codexDesktop &&
-                (session.status.isActiveVisual || now.timeIntervalSince(session.updatedAt) < 45)
-        }
-        return hasRecentOrActiveDesktop ? 2.5 : 8.0
+        CodexRefreshCadencePolicy.interval(sessions: sessions, isExpanded: isExpanded)
     }
 
     func subagents(
@@ -364,11 +356,7 @@ extension SessionStore {
 
     func startCodexDesktopRefreshTimer() {
         guard refreshTimer == nil else { return }
-        refreshTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                await self?.refreshCodexDesktop()
-            }
-        }
+        scheduleNextCodexDesktopRefresh()
     }
 
     func stopCodexDesktopRefreshTimer() {
@@ -376,16 +364,48 @@ extension SessionStore {
         refreshTimer = nil
     }
 
+    /// 单发自排程：每次刷新完按当前活跃度决定下一次唤醒，替代固定 1 秒轮询。
+    func scheduleNextCodexDesktopRefresh() {
+        refreshTimer?.invalidate()
+        let interval = CodexRefreshCadencePolicy.interval(sessions: sessions, isExpanded: isExpanded)
+        let timer = Timer(timeInterval: interval, repeats: false) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                await self.refreshCodexDesktop()
+                guard self.refreshTimer != nil else { return }
+                self.scheduleNextCodexDesktopRefresh()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        refreshTimer = timer
+    }
+
     func startVisibilityTimer() {
-        guard visibilityTimer == nil else { return }
-        visibilityTimer = Timer.scheduledTimer(withTimeInterval: 15.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
+        scheduleVisibilityRefresh()
+    }
+
+    /// 只在真正需要的时刻唤醒：面板展开时按 15 秒刷新相对时间，折叠时只在
+    /// 会话跨可见性边界的精确时刻唤醒；无会话则完全不设定时器。
+    func scheduleVisibilityRefresh() {
+        visibilityTimer?.invalidate()
+        visibilityTimer = nil
+        guard let delay = SessionAgingSchedulePolicy.nextRefreshDelay(
+            sessions: sessions,
+            isExpanded: isExpanded
+        ) else {
+            return
+        }
+        let timer = Timer(timeInterval: delay, repeats: false) { [weak self] _ in
+            Task { @MainActor [weak self] in
                 self?.refreshVisibleSessionAging()
             }
         }
+        RunLoop.main.add(timer, forMode: .common)
+        visibilityTimer = timer
     }
 
     func refreshVisibleSessionAging() {
+        defer { scheduleVisibilityRefresh() }
         guard !sessions.isEmpty else { return }
         let visible = DashboardSessionPolicy.visibleSessions(from: sessions, limit: configuredVisibleSessionLimit)
         if let selectedSessionID,

--- a/Sources/VibelslandFree/SessionStore.swift
+++ b/Sources/VibelslandFree/SessionStore.swift
@@ -7,9 +7,19 @@ import SwiftUI
 
 @MainActor
 final class SessionStore: ObservableObject {
-    @Published var sessions: [AgentSession] = []
+    @Published var sessions: [AgentSession] = [] {
+        didSet { scheduleVisibilityRefresh() }
+    }
     @Published var selectedSessionID: AgentSession.ID?
-    @Published var isExpanded = false
+    @Published var isExpanded = false {
+        didSet {
+            guard isExpanded != oldValue else { return }
+            scheduleVisibilityRefresh()
+            if refreshTimer != nil {
+                scheduleNextCodexDesktopRefresh()
+            }
+        }
+    }
     @Published var installReport: InstallReport?
     @Published var lastError: String?
     @Published var lastRepairMessage: String?

--- a/Sources/VibelslandFreeCore/RefreshSchedulingPolicy.swift
+++ b/Sources/VibelslandFreeCore/RefreshSchedulingPolicy.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Codex Desktop 状态刷新的节奏。旧实现用 1 秒固定定时器撞节流墙（大部分
+/// 唤醒直接空转），这里让定时器本身按同一套间隔自排程：刷新频率不变，
+/// 进程唤醒次数在空闲时降到原来的 1/8。
+package enum CodexRefreshCadencePolicy {
+    package static let expandedInterval: TimeInterval = 2.0
+    package static let recentActivityInterval: TimeInterval = 2.5
+    package static let idleInterval: TimeInterval = 8.0
+    package static let recentActivityWindow: TimeInterval = 45
+
+    package static func interval(
+        sessions: [AgentSession],
+        isExpanded: Bool,
+        now: Date = Date()
+    ) -> TimeInterval {
+        if isExpanded {
+            return expandedInterval
+        }
+        let hasRecentOrActiveDesktop = sessions.contains { session in
+            session.source == .codexDesktop &&
+                (session.status.isActiveVisual || now.timeIntervalSince(session.updatedAt) < recentActivityWindow)
+        }
+        return hasRecentOrActiveDesktop ? recentActivityInterval : idleInterval
+    }
+}
+
+/// 会话老化刷新的按需调度。旧实现每 15 秒固定唤醒；实际上只有两类时刻需要
+/// 唤醒：面板展开时刷新相对时间文本（保持 15 秒），以及某个会话跨过
+/// 可见性边界（完成 2 分钟、失败 10 分钟、空闲 45 秒、活跃 2 小时）的精确
+/// 时刻。折叠且没有会话临近边界时完全不唤醒。
+package enum SessionAgingSchedulePolicy {
+    package static let expandedRefreshInterval: TimeInterval = 15
+    package static let minimumDelay: TimeInterval = 1
+
+    package static func nextRefreshDelay(
+        sessions: [AgentSession],
+        isExpanded: Bool,
+        now: Date = Date()
+    ) -> TimeInterval? {
+        guard !sessions.isEmpty else { return nil }
+        var delays: [TimeInterval] = []
+        if isExpanded {
+            delays.append(expandedRefreshInterval)
+        }
+        for session in sessions {
+            if let remaining = hideDelay(for: session, now: now) {
+                delays.append(remaining)
+            }
+        }
+        guard let next = delays.min() else { return nil }
+        return max(minimumDelay, next)
+    }
+
+    /// 该会话距离「从面板消失」还剩多久；nil 表示没有时间驱动的转换点
+    /// （已经不可见，或有待审批——审批的消失由解决事件驱动）。
+    package static func hideDelay(for session: AgentSession, now: Date = Date()) -> TimeInterval? {
+        guard DashboardSessionPolicy.isVisible(session, now: now) else { return nil }
+        if let approval = session.approval, !approval.isExpired {
+            return nil
+        }
+        let age = now.timeIntervalSince(session.updatedAt)
+        let hideAfter: TimeInterval
+        switch session.status {
+        case .done:
+            hideAfter = DashboardSessionPolicy.completedHideAfter
+        case .failed:
+            hideAfter = DashboardSessionPolicy.failedHideAfter
+        case .idle:
+            hideAfter = DashboardSessionPolicy.idleHideAfter
+        case .thinking, .runningTool, .waitingApproval, .waitingQuestion:
+            hideAfter = DashboardSessionPolicy.activeHideAfter
+        }
+        return hideAfter - age
+    }
+}
+
+/// 展开面板离开鼠标后自动收起。旧实现 0.22 秒轮询鼠标位置 30 tick；
+/// 事件驱动版由 NSTrackingArea 进出事件触发，宽限时长保持一致。
+package enum IslandAutoCollapsePolicy {
+    package static let graceDuration: TimeInterval = 6.6
+}

--- a/Tests/VibelslandFreeCoreTests/RefreshSchedulingPolicyTests.swift
+++ b/Tests/VibelslandFreeCoreTests/RefreshSchedulingPolicyTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+@testable import VibelslandFreeCore
+
+@Suite
+struct RefreshSchedulingPolicyTests {
+    @Test func testCodexCadenceMatchesLegacyThrottle() {
+        let now = Date()
+        XCTAssertEqual(
+            CodexRefreshCadencePolicy.interval(sessions: [], isExpanded: true, now: now),
+            2.0,
+            "Expanded island refreshes every 2 seconds"
+        )
+        XCTAssertEqual(
+            CodexRefreshCadencePolicy.interval(sessions: [], isExpanded: false, now: now),
+            8.0,
+            "Idle with no desktop sessions backs off to 8 seconds"
+        )
+
+        let active = schedulingSession(id: "a", source: .codexDesktop, status: .runningTool, updatedAt: now)
+        XCTAssertEqual(
+            CodexRefreshCadencePolicy.interval(sessions: [active], isExpanded: false, now: now),
+            2.5,
+            "Active desktop session keeps the 2.5 second cadence"
+        )
+
+        let recent = schedulingSession(id: "r", source: .codexDesktop, status: .done, updatedAt: now.addingTimeInterval(-30))
+        XCTAssertEqual(
+            CodexRefreshCadencePolicy.interval(sessions: [recent], isExpanded: false, now: now),
+            2.5,
+            "Recently updated desktop session counts as active"
+        )
+
+        let stale = schedulingSession(id: "s", source: .codexDesktop, status: .done, updatedAt: now.addingTimeInterval(-90))
+        XCTAssertEqual(
+            CodexRefreshCadencePolicy.interval(sessions: [stale], isExpanded: false, now: now),
+            8.0,
+            "Stale desktop session backs off"
+        )
+
+        let claudeOnly = schedulingSession(id: "c", source: .claudeCode, status: .runningTool, updatedAt: now)
+        XCTAssertEqual(
+            CodexRefreshCadencePolicy.interval(sessions: [claudeOnly], isExpanded: false, now: now),
+            8.0,
+            "Non-desktop sessions do not affect the desktop cadence"
+        )
+    }
+
+    @Test func testAgingScheduleSkipsWorkWhenNothingChanges() {
+        let now = Date()
+        XCTAssertTrue(
+            SessionAgingSchedulePolicy.nextRefreshDelay(sessions: [], isExpanded: true, now: now) == nil,
+            "No sessions means no timer at all"
+        )
+
+        let hidden = schedulingSession(id: "h", source: .claudeCode, status: .done, updatedAt: now.addingTimeInterval(-600))
+        XCTAssertTrue(
+            SessionAgingSchedulePolicy.nextRefreshDelay(sessions: [hidden], isExpanded: false, now: now) == nil,
+            "Collapsed with only already-hidden sessions never wakes"
+        )
+
+        let approval = approvalSchedulingSession(id: "ap", createdAt: now)
+        XCTAssertTrue(
+            SessionAgingSchedulePolicy.nextRefreshDelay(sessions: [approval], isExpanded: false, now: now) == nil,
+            "Pending approvals are event-driven, not time-driven"
+        )
+    }
+
+    @Test func testAgingScheduleWakesAtVisibilityBoundaries() {
+        let now = Date()
+        let idle = schedulingSession(id: "i", source: .claudeCode, status: .idle, updatedAt: now.addingTimeInterval(-30))
+        let delay = SessionAgingSchedulePolicy.nextRefreshDelay(sessions: [idle], isExpanded: false, now: now)
+        XCTAssertEqual(delay ?? -1, 15, "Idle session hides at 45s, so wake in 15s")
+
+        let done = schedulingSession(id: "d", source: .claudeCode, status: .done, updatedAt: now.addingTimeInterval(-100))
+        let doneDelay = SessionAgingSchedulePolicy.nextRefreshDelay(sessions: [done], isExpanded: false, now: now)
+        XCTAssertEqual(doneDelay ?? -1, 20, "Done session hides at 120s, so wake in 20s")
+
+        let both = SessionAgingSchedulePolicy.nextRefreshDelay(sessions: [idle, done], isExpanded: false, now: now)
+        XCTAssertEqual(both ?? -1, 15, "The earliest boundary wins")
+
+        let expanded = SessionAgingSchedulePolicy.nextRefreshDelay(sessions: [done], isExpanded: true, now: now)
+        XCTAssertEqual(expanded ?? -1, 15, "Expanded panel keeps the 15s relative-time refresh")
+
+        let imminent = schedulingSession(id: "m", source: .claudeCode, status: .idle, updatedAt: now.addingTimeInterval(-44.9))
+        let clamped = SessionAgingSchedulePolicy.nextRefreshDelay(sessions: [imminent], isExpanded: false, now: now)
+        XCTAssertEqual(clamped ?? -1, SessionAgingSchedulePolicy.minimumDelay, "Imminent boundaries clamp to the minimum delay")
+    }
+
+    @Test func testAutoCollapseGraceMatchesLegacyPolling() {
+        XCTAssertEqual(
+            IslandAutoCollapsePolicy.graceDuration,
+            6.6,
+            "Grace duration preserves the old 30 ticks at 0.22s"
+        )
+    }
+
+    private func schedulingSession(
+        id: String,
+        source: AgentSource,
+        status: SessionStatus,
+        updatedAt: Date
+    ) -> AgentSession {
+        AgentSession(
+            id: id,
+            title: id,
+            prompt: id,
+            source: source,
+            workspace: "/tmp/vibelsland",
+            terminal: source.displayName,
+            updatedAt: updatedAt,
+            status: status,
+            activity: [],
+            approval: nil,
+            question: nil,
+            subagents: [],
+            lastAssistantMessage: nil,
+            lastUserMessage: nil,
+            usage: nil
+        )
+    }
+
+    private func approvalSchedulingSession(id: String, createdAt: Date) -> AgentSession {
+        var session = schedulingSession(id: id, source: .claudeCode, status: .waitingApproval, updatedAt: createdAt)
+        session.approval = ApprovalRequest(
+            id: "approval-\(id)",
+            source: .claudeCode,
+            title: "Approval",
+            detail: "run command",
+            tool: "Bash",
+            workspace: "/tmp/vibelsland",
+            suggestedSessionAllow: false,
+            supportsCancel: false,
+            createdAt: createdAt
+        )
+        return session
+    }
+}


### PR DESCRIPTION
## 概要

三个常驻定时器停止无意义唤醒，刷新频率与收起时长**完全不变**：

| 定时器 | 之前 | 之后 |
|---|---|---|
| Codex Desktop 轮询 | 固定 1s 唤醒撞 2/2.5/8s 节流墙 | 按节流节奏自排程 one-shot，空闲唤醒降至 1/8 |
| 会话老化刷新 | 无条件每 15s | 只在最近的可见性边界精确唤醒；展开时保留 15s 相对时间刷新；无会话不设定时器 |
| 鼠标离开收起 | 0.22s 轮询光标位置 | NSTrackingArea 进出事件 + 6.6s 一次性宽限定时器（触发时二次确认位置，容忍动画期漏事件） |

## 实现

- 节奏参数提取为 `CodexRefreshCadencePolicy` / `SessionAgingSchedulePolicy` / `IslandAutoCollapsePolicy`（Core 可单测），节流与调度共用一套数字。
- store 状态变化（展开/会话变更）立即重排两条链，节奏切换不等旧间隔耗尽。
- 审批的显示消失保持事件驱动，不参与时间调度。

## 验证

- 策略断言独立进程 15 项全过。
- 真实 App 窗口自动化回归全过：**陈旧事件→空闲窗口**（验证按需调度的老化链路真实生效）、idle window、expand/collapse visibility、单审批 236pt、审批队列 288pt。

## 合并顺序

堆叠 PR 链第 **6/6** 个（最后合并），base 为 `feat/claude-usage-cost`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)