### PR TITLE
build: produce a universal binary in release packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 
+- Release packaging now builds a Universal Binary (Apple Silicon + Intel): each architecture compiles separately and merges via lipo so the flow works without full Xcode, and build/verify scripts assert both slices are present. Applies from the next release; the published v0.1.0 package remains arm64-only.
 - Reduced background wakeups: the Codex Desktop poller now self-schedules at its adaptive cadence instead of ticking every second, session-aging refresh only wakes at actual visibility boundaries (and not at all when idle and collapsed), and the expanded island's mouse-leave auto-collapse is driven by tracking-area events instead of a 0.22s mouse poll. Refresh rates and collapse timing are unchanged.
 - Added Claude Code token usage to session details: per-turn and cumulative token counts parsed incrementally from local transcripts, plus an estimated API-equivalent cost for recognized model families.
 - Added an update checker in settings: a manual "Check for updates" button plus an optional launch-time check (off by default); the GitHub releases API is contacted only on explicit user action, keeping the local-first promise.

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -20,19 +20,41 @@ APP_NAME="${APP_BUNDLE_NAME%.app}"
 BUNDLE_ID="$metadata[2]"
 APP_VERSION="$metadata[3]"
 BUILD_NUMBER="$metadata[4]"
-BUILD_DIR="$ROOT/.build/release"
 DIST_DIR="$ROOT/dist"
 APP_DIR="$DIST_DIR/$APP_BUNDLE_NAME"
 CONTENTS="$APP_DIR/Contents"
 MACOS="$CONTENTS/MacOS"
 RESOURCES="$CONTENTS/Resources"
 
+# 发布包默认构建 Universal Binary（Apple Silicon + Intel）。
+# 本地想加速可用 VIBELSLAND_BUILD_ARCHS=arm64 只出单架构。
+# 注意：一次传多个 --arch 需要完整 Xcode 的 xcbuild，CommandLineTools
+# 环境不可用，所以逐架构编译后用 lipo 合并。
+BUILD_ARCHS="${VIBELSLAND_BUILD_ARCHS:-arm64 x86_64}"
+
 cd "$ROOT"
-swift build -c release
+ARCH_BINARIES=()
+for arch in ${=BUILD_ARCHS}; do
+    swift build -c release --arch "$arch"
+    ARCH_BINARIES+=("$(swift build -c release --arch "$arch" --show-bin-path)/VibelslandFree")
+done
 
 rm -rf "$APP_DIR"
 mkdir -p "$MACOS" "$RESOURCES"
-cp "$BUILD_DIR/VibelslandFree" "$MACOS/VibelslandFree"
+if (( ${#ARCH_BINARIES[@]} == 1 )); then
+    cp "${ARCH_BINARIES[1]}" "$MACOS/VibelslandFree"
+else
+    /usr/bin/lipo -create "${ARCH_BINARIES[@]}" -output "$MACOS/VibelslandFree"
+fi
+
+# 断言二进制包含请求的所有架构，防止发布包悄悄退化成单架构。
+BINARY_ARCHS="$(/usr/bin/lipo -archs "$MACOS/VibelslandFree")"
+for arch in ${=BUILD_ARCHS}; do
+    if [[ " $BINARY_ARCHS " != *" $arch "* ]]; then
+        echo "build-app: missing architecture $arch (got: $BINARY_ARCHS)" >&2
+        exit 1
+    fi
+done
 
 ICON_TMP="$(mktemp -d "${TMPDIR:-/tmp}/vibelsland-icon.XXXXXX")"
 trap 'rm -rf "$ICON_TMP"' EXIT

--- a/scripts/verify-app.sh
+++ b/scripts/verify-app.sh
@@ -47,4 +47,14 @@ SIGNATURE_INFO="$(/usr/bin/codesign -dv --verbose=4 "$APP_DIR" 2>&1)"
 [[ -x "$EXECUTABLE" ]]
 [[ -s "$ICON" ]]
 
-echo "App verification passed"
+# 与 build-app.sh 相同的架构约定：发布验证默认要求 Universal Binary。
+BUILD_ARCHS="${VIBELSLAND_BUILD_ARCHS:-arm64 x86_64}"
+BINARY_ARCHS="$(/usr/bin/lipo -archs "$EXECUTABLE")"
+for arch in ${=BUILD_ARCHS}; do
+    if [[ " $BINARY_ARCHS " != *" $arch "* ]]; then
+        echo "verify-app: missing architecture $arch (got: $BINARY_ARCHS)" >&2
+        exit 1
+    fi
+done
+
+echo "App verification passed (archs: $BINARY_ARCHS)"


### PR DESCRIPTION
## 概要

发布打包默认产出 **Universal Binary**（Apple Silicon + Intel）。已发布的 v0.1.0 包不变，从下一个 release 生效。

## 实现

- 关键约束：多 `--arch` 的 `swift build` 走 xcbuild（需完整 Xcode），维护者机器只有 CommandLineTools——所以**逐架构编译 + `lipo -create` 合并**。
- 默认 `arm64 x86_64`，本地可用 `VIBELSLAND_BUILD_ARCHS=arm64` 加速单架构构建。
- `build-app.sh` 和 `verify-app.sh` 都用 `lipo -archs` 断言所有请求的架构切片存在，发布包不可能悄悄退化成单架构。

## 验证

- 本机（CLT-only）实际构建出 `x86_64 arm64` 双架构 7.8MB 产物，codesign 通过。
- Universal app 跑审批窗口自动化通过（236pt）。
- 单架构覆盖路径（env 变量）验证正常。

## 合并顺序

堆叠 PR 链第 **7/9** 个，base 为 `perf/adaptive-timers`（PR #9）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)