### PR TITLE
feat: add local statistics panel for sessions, approvals, and tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 
+- Added a local statistics card in settings: today/last-7-days session, approval, and token/cost counters with a per-day token mini chart. Counters are aggregate-only (no session content), stay on this Mac, keep 30 days, and can be cleared anytime.
 - Release packaging now builds a Universal Binary (Apple Silicon + Intel): each architecture compiles separately and merges via lipo so the flow works without full Xcode, and build/verify scripts assert both slices are present. Applies from the next release; the published v0.1.0 package remains arm64-only.
 - Reduced background wakeups: the Codex Desktop poller now self-schedules at its adaptive cadence instead of ticking every second, session-aging refresh only wakes at actual visibility boundaries (and not at all when idle and collapsed), and the expanded island's mouse-leave auto-collapse is driven by tracking-area events instead of a 0.22s mouse poll. Refresh rates and collapse timing are unchanged.
 - Added Claude Code token usage to session details: per-turn and cumulative token counts parsed incrementally from local transcripts, plus an estimated API-equivalent cost for recognized model families.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -20,6 +20,7 @@ The app may read:
 The app writes:
 
 - Configuration at `~/Library/Application Support/VibelslandFree/config.json`.
+- Local statistics at `~/Library/Application Support/VibelslandFree/stats.json`: per-day aggregate counters only (session, approval, and token/cost totals). It never contains prompts, commands, file paths, or any session content, keeps at most 30 days, and can be cleared from the settings page at any time.
 - Logs at `~/Library/Logs/VibelslandFree/app.log`.
 - Runtime bridge files under `~/.vibelsland-free`, including the local Unix socket and a local bridge token.
 - Hook configuration changes only when the user installs, repairs, or uninstalls hooks.

--- a/Sources/VibelslandFree/AppDelegate.swift
+++ b/Sources/VibelslandFree/AppDelegate.swift
@@ -342,6 +342,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject, NSWi
         NSApp.terminate(nil)
     }
 
+    func applicationWillTerminate(_ notification: Notification) {
+        store.statsStore.flush()
+    }
+
     @objc func restart() {
         let appPath = Bundle.main.bundleURL.path
         guard let command = AppRestartPolicy.command(bundlePath: appPath) else {

--- a/Sources/VibelslandFree/SessionStore+Approvals.swift
+++ b/Sources/VibelslandFree/SessionStore+Approvals.swift
@@ -93,6 +93,8 @@ extension SessionStore {
     }
 
     func markApprovalResolved(_ id: String, decision: ApprovalDecision) {
+        let resolutionState = approvalResolutionState(for: decision)
+        statsStore.record { $0.recordApprovalResolution(resolutionState) }
         for index in sessions.indices {
             if sessions[index].approval?.id == id {
                 let state = approvalResolutionState(for: decision)
@@ -155,6 +157,7 @@ extension SessionStore {
         let approvalID = "codex-desktop-approval-\(requestKey)"
         let decision = pendingCodexDesktopDecisions[approvalID] ?? .accept
         let state = approvalResolutionState(for: decision)
+        statsStore.record { $0.recordApprovalResolution(state) }
         for index in sessions.indices where sessions[index].approval?.id == approvalID {
             sessions[index].activity.append(ActivityItem(
                 symbol: approvalResolutionSymbol(for: state),

--- a/Sources/VibelslandFree/SessionStore+Events.swift
+++ b/Sources/VibelslandFree/SessionStore+Events.swift
@@ -319,6 +319,7 @@ extension SessionStore {
 
     func upsert(_ session: AgentSession) {
         let session = SessionMemoryPolicy.compact(session)
+        recordStatsTransition(previous: sessions.first { $0.id == session.id }, current: session)
         if let index = sessions.firstIndex(where: { $0.id == session.id }) {
             sessions[index] = session
         } else {
@@ -330,6 +331,34 @@ extension SessionStore {
         sessions.sort { $0.updatedAt > $1.updatedAt }
         sessions = Array(sessions.prefix(configuredVisibleSessionLimit))
         selectedSessionID = selectedSessionID ?? sessions.first?.id
+    }
+
+    /// 只记录状态转移与增量，upsert 的重复回放（如 Codex 刷新重建会话）不会重复计数。
+    func recordStatsTransition(previous: AgentSession?, current: AgentSession) {
+        let delta = UsageStatsPolicy.usageDelta(previous: previous?.usage, current: current.usage)
+        let started = previous == nil
+        let completed = previous?.status != .done && current.status == .done
+        let failed = previous?.status != .failed && current.status == .failed
+        let approvalReceived = current.approval != nil && previous?.approval?.id != current.approval?.id
+        guard started || completed || failed || approvalReceived || delta.tokens > 0 || delta.costUSD > 0 else {
+            return
+        }
+        statsStore.record { day in
+            if started {
+                day.recordSessionStarted(source: current.source)
+            }
+            if completed {
+                day.sessionsCompleted += 1
+            }
+            if failed {
+                day.sessionsFailed += 1
+            }
+            if approvalReceived {
+                day.approvalsReceived += 1
+            }
+            day.tokens += delta.tokens
+            day.estimatedCostUSD += delta.costUSD
+        }
     }
 
     func handleConfigurationChanged() {

--- a/Sources/VibelslandFree/SessionStore.swift
+++ b/Sources/VibelslandFree/SessionStore.swift
@@ -46,6 +46,7 @@ final class SessionStore: ObservableObject {
     let codexAppServerLiveClient: CodexAppServerLiveClient
     let transcriptReader: ConversationTranscriptReader
     let approvalNotificationCenter = ApprovalNotificationCenter()
+    let statsStore = UsageStatsStore()
     let logger: AppLogger
     var pendingReplies: [String: (String?) -> Void] = [:]
     var pendingEvents: [String: AgentEvent] = [:]

--- a/Sources/VibelslandFree/SettingsView.swift
+++ b/Sources/VibelslandFree/SettingsView.swift
@@ -64,6 +64,8 @@ struct SettingsView: View {
                     check: store.checkForUpdates
                 )
 
+                StatsSection(statsStore: store.statsStore)
+
                 DiagnosticsSection(
                     codexAppServerReachable: store.codexAppServerReachable,
                     codexAppServerThreadListAvailable: store.codexAppServerThreadListAvailable,
@@ -558,6 +560,112 @@ private struct ApprovalPreferencesSection: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.top, 10)
             }
+        }
+    }
+}
+
+private struct StatsSection: View {
+    @EnvironmentObject private var configurationStore: AppConfigurationStore
+    @ObservedObject var statsStore: UsageStatsStore
+
+    var body: some View {
+        SettingsCard(
+            title: AppText.pick(configurationStore.config.language, english: "Statistics", japanese: "統計", chinese: "统计"),
+            subtitle: AppText.pick(
+                configurationStore.config.language,
+                english: "Aggregate counters kept only on this Mac — no prompts, commands, or session content. Last 30 days.",
+                japanese: "この Mac にのみ保存される集計カウンターです。プロンプトや会話内容は含まれません。直近 30 日分。",
+                chinese: "仅保存在本机的聚合计数，不含任何提示词、命令或会话内容；保留最近 30 天。"
+            )
+        ) {
+            VStack(alignment: .leading, spacing: 12) {
+                statsRow(
+                    label: AppText.pick(configurationStore.config.language, english: "Today", japanese: "今日", chinese: "今日"),
+                    stats: statsStore.todayStats()
+                )
+                SettingsDivider()
+                statsRow(
+                    label: AppText.pick(configurationStore.config.language, english: "Last 7 days", japanese: "直近 7 日", chinese: "近 7 天"),
+                    stats: statsStore.weekStats()
+                )
+                tokenBars
+                HStack {
+                    Spacer()
+                    Button(AppText.pick(configurationStore.config.language, english: "Clear statistics", japanese: "統計を消去", chinese: "清除统计")) {
+                        statsStore.clearAll()
+                    }
+                    .font(.system(size: 12, weight: .medium))
+                }
+            }
+        }
+    }
+
+    private func statsRow(label: String, stats: DailyStats) -> some View {
+        HStack(spacing: 14) {
+            Text(label)
+                .font(.system(size: 13, weight: .semibold))
+                .frame(width: 76, alignment: .leading)
+            statMetric(
+                AppText.pick(configurationStore.config.language, english: "Sessions", japanese: "セッション", chinese: "会话"),
+                "\(stats.sessionsStartedTotal)"
+            )
+            statMetric(
+                AppText.pick(configurationStore.config.language, english: "Done", japanese: "完了", chinese: "完成"),
+                "\(stats.sessionsCompleted)"
+            )
+            statMetric(
+                AppText.pick(configurationStore.config.language, english: "Approvals", japanese: "承認", chinese: "审批"),
+                approvalSummary(stats)
+            )
+            statMetric("Token", UsageSnapshot.compactNumber(stats.tokens))
+            if stats.estimatedCostUSD > 0 {
+                statMetric(
+                    AppText.pick(configurationStore.config.language, english: "Est.", japanese: "概算", chinese: "估算"),
+                    UsageSnapshot.costText(stats.estimatedCostUSD)
+                )
+            }
+            Spacer()
+        }
+    }
+
+    private func approvalSummary(_ stats: DailyStats) -> String {
+        guard stats.approvalsReceived > 0 else { return "0" }
+        return "\(stats.approvalsReceived) (✓\(stats.approvalsAccepted) ✕\(stats.approvalsDeclined))"
+    }
+
+    private func statMetric(_ title: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: 12, weight: .semibold))
+                .monospacedDigit()
+        }
+    }
+
+    private var tokenBars: some View {
+        let days = statsStore.recentDays()
+        let maxTokens = max(1, days.map(\.stats.tokens).max() ?? 1)
+        return VStack(alignment: .leading, spacing: 4) {
+            Text(AppText.pick(configurationStore.config.language, english: "Tokens per day", japanese: "日別トークン", chinese: "每日 Token"))
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+            HStack(alignment: .bottom, spacing: 10) {
+                ForEach(days, id: \.key) { day in
+                    VStack(spacing: 3) {
+                        RoundedRectangle(cornerRadius: 2, style: .continuous)
+                            .fill(day.stats.tokens > 0 ? Color.accentColor.opacity(0.75) : Color.secondary.opacity(0.25))
+                            .frame(width: 26, height: max(3, CGFloat(day.stats.tokens) / CGFloat(maxTokens) * 44))
+                            .help("\(day.key): \(UsageSnapshot.compactNumber(day.stats.tokens))")
+                        Text(String(day.key.suffix(2)))
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                Spacer()
+            }
+            .frame(height: 62, alignment: .bottom)
         }
     }
 }

--- a/Sources/VibelslandFreeCore/AppPaths.swift
+++ b/Sources/VibelslandFreeCore/AppPaths.swift
@@ -45,6 +45,10 @@ package enum AppPaths {
         applicationSupportDirectory.appendingPathComponent("config.json")
     }
 
+    package static var statsURL: URL {
+        applicationSupportDirectory.appendingPathComponent("stats.json")
+    }
+
     package static var logsDirectory: URL {
         home.appendingPathComponent("Library/Logs/VibelslandFree", isDirectory: true)
     }

--- a/Sources/VibelslandFreeCore/UsageStatsStore.swift
+++ b/Sources/VibelslandFreeCore/UsageStatsStore.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+/// 一天的本地统计：只有计数与合计，不含任何提示词、命令或会话内容。
+package struct DailyStats: Codable, Equatable {
+    package var sessionsStarted: [String: Int] = [:]
+    package var sessionsCompleted = 0
+    package var sessionsFailed = 0
+    package var approvalsReceived = 0
+    package var approvalsAccepted = 0
+    package var approvalsDeclined = 0
+    package var approvalsCancelled = 0
+    package var tokens = 0
+    package var estimatedCostUSD = 0.0
+
+    package init() {}
+
+    package var sessionsStartedTotal: Int {
+        sessionsStarted.values.reduce(0, +)
+    }
+
+    package mutating func recordSessionStarted(source: AgentSource) {
+        sessionsStarted[source.rawValue, default: 0] += 1
+    }
+
+    package mutating func recordApprovalResolution(_ state: ApprovalResolutionState) {
+        switch state {
+        case .accepted:
+            approvalsAccepted += 1
+        case .declined:
+            approvalsDeclined += 1
+        case .cancelled:
+            approvalsCancelled += 1
+        case .pending, .resolving, .timedOut, .sendFailed, .disconnected:
+            break
+        }
+    }
+
+    package mutating func merge(_ other: DailyStats) {
+        for (key, value) in other.sessionsStarted {
+            sessionsStarted[key, default: 0] += value
+        }
+        sessionsCompleted += other.sessionsCompleted
+        sessionsFailed += other.sessionsFailed
+        approvalsReceived += other.approvalsReceived
+        approvalsAccepted += other.approvalsAccepted
+        approvalsDeclined += other.approvalsDeclined
+        approvalsCancelled += other.approvalsCancelled
+        tokens += other.tokens
+        estimatedCostUSD += other.estimatedCostUSD
+    }
+}
+
+package enum UsageStatsPolicy {
+    package static let retentionDays = 30
+
+    package static func dayKey(
+        for date: Date,
+        calendar: Calendar = .current
+    ) -> String {
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", components.year ?? 0, components.month ?? 0, components.day ?? 0)
+    }
+
+    /// 最近 count 天的 key（含当天），从旧到新。
+    package static func recentDayKeys(
+        endingAt date: Date = Date(),
+        count: Int = 7,
+        calendar: Calendar = .current
+    ) -> [String] {
+        (0..<max(0, count)).reversed().compactMap { offset in
+            calendar.date(byAdding: .day, value: -offset, to: date).map { dayKey(for: $0, calendar: calendar) }
+        }
+    }
+
+    package static func prune(
+        _ days: [String: DailyStats],
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> [String: DailyStats] {
+        let keep = Set(recentDayKeys(endingAt: now, count: retentionDays, calendar: calendar))
+        return days.filter { keep.contains($0.key) }
+    }
+
+    package static func total(of days: [DailyStats]) -> DailyStats {
+        var result = DailyStats()
+        for day in days {
+            result.merge(day)
+        }
+        return result
+    }
+
+    /// 会话累计值的日增量：token/成本都是会话内单调递增的累计数，
+    /// 记录相邻快照的正向差值；数值回退（会话重置）时按新值重新起算。
+    package static func usageDelta(
+        previous: UsageSnapshot?,
+        current: UsageSnapshot?
+    ) -> (tokens: Int, costUSD: Double) {
+        guard let current else { return (0, 0) }
+        let previousTokens = previous?.totalTokens ?? 0
+        let previousCost = previous?.estimatedCostUSD ?? 0
+        let currentCost = current.estimatedCostUSD ?? 0
+        let tokens = current.totalTokens >= previousTokens
+            ? current.totalTokens - previousTokens
+            : current.totalTokens
+        let cost = currentCost >= previousCost
+            ? currentCost - previousCost
+            : currentCost
+        return (max(0, tokens), max(0, cost))
+    }
+}
+
+/// 本地统计的持久化：Application Support/VibelslandFree/stats.json。
+/// 只写聚合计数；保留最近 30 天；写入去抖合并。
+@MainActor
+package final class UsageStatsStore: ObservableObject {
+    @Published package private(set) var days: [String: DailyStats]
+
+    private let url: URL
+    private let logger: AppLogger
+    private var saveTimer: Timer?
+
+    package init(url: URL = AppPaths.statsURL, logger: AppLogger = .shared) {
+        self.url = url
+        self.logger = logger
+        if let data = try? Data(contentsOf: url),
+           let decoded = try? JSONDecoder().decode([String: DailyStats].self, from: data) {
+            days = UsageStatsPolicy.prune(decoded)
+        } else {
+            days = [:]
+        }
+    }
+
+    package func record(on date: Date = Date(), _ mutation: (inout DailyStats) -> Void) {
+        let key = UsageStatsPolicy.dayKey(for: date)
+        var day = days[key] ?? DailyStats()
+        mutation(&day)
+        days[key] = day
+        days = UsageStatsPolicy.prune(days, now: date)
+        scheduleSave()
+    }
+
+    package func stats(forDayKey key: String) -> DailyStats {
+        days[key] ?? DailyStats()
+    }
+
+    package func todayStats(now: Date = Date()) -> DailyStats {
+        stats(forDayKey: UsageStatsPolicy.dayKey(for: now))
+    }
+
+    package func weekStats(now: Date = Date()) -> DailyStats {
+        UsageStatsPolicy.total(of: UsageStatsPolicy.recentDayKeys(endingAt: now).map { stats(forDayKey: $0) })
+    }
+
+    package func recentDays(now: Date = Date(), count: Int = 7) -> [(key: String, stats: DailyStats)] {
+        UsageStatsPolicy.recentDayKeys(endingAt: now, count: count).map { ($0, stats(forDayKey: $0)) }
+    }
+
+    package func clearAll() {
+        days = [:]
+        saveTimer?.invalidate()
+        saveTimer = nil
+        try? FileManager.default.removeItem(at: url)
+        logger.info("stats.cleared")
+    }
+
+    package func flush() {
+        saveTimer?.invalidate()
+        saveTimer = nil
+        save()
+    }
+
+    private func scheduleSave() {
+        guard saveTimer == nil else { return }
+        let timer = Timer(timeInterval: 2.0, repeats: false) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.saveTimer = nil
+                self?.save()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        saveTimer = timer
+    }
+
+    private func save() {
+        do {
+            try AppPaths.ensureRuntimeDirectories()
+            let data = try JSONEncoder.pretty.encode(days)
+            try data.write(to: url, options: [.atomic])
+        } catch {
+            logger.error("stats.save.failed", detail: error.localizedDescription)
+        }
+    }
+}

--- a/Tests/VibelslandFreeCoreTests/UsageStatsTests.swift
+++ b/Tests/VibelslandFreeCoreTests/UsageStatsTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import VibelslandFreeCore
+
+@Suite
+struct UsageStatsTests {
+    @Test func testDayKeyFormatsCalendarDay() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Tokyo")!
+        // 2026-07-04 00:30 JST
+        let date = DateComponents(calendar: calendar, year: 2026, month: 7, day: 4, hour: 0, minute: 30).date!
+        XCTAssertEqual(UsageStatsPolicy.dayKey(for: date, calendar: calendar), "2026-07-04", "Day key uses the local calendar day")
+    }
+
+    @Test func testRecentDayKeysAreOrderedOldestFirst() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Tokyo")!
+        let date = DateComponents(calendar: calendar, year: 2026, month: 7, day: 4, hour: 12).date!
+        let keys = UsageStatsPolicy.recentDayKeys(endingAt: date, count: 3, calendar: calendar)
+        XCTAssertEqual(keys, ["2026-07-02", "2026-07-03", "2026-07-04"], "Keys run oldest to newest and include today")
+    }
+
+    @Test func testPruneKeepsOnlyRetentionWindow() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Tokyo")!
+        let now = DateComponents(calendar: calendar, year: 2026, month: 7, day: 4, hour: 12).date!
+        var days: [String: DailyStats] = [:]
+        days["2026-07-04"] = DailyStats()
+        days["2026-06-05"] = DailyStats() // 29 天前，保留
+        days["2026-06-01"] = DailyStats() // 33 天前，裁掉
+        days["2020-01-01"] = DailyStats()
+        let pruned = UsageStatsPolicy.prune(days, now: now, calendar: calendar)
+        XCTAssertTrue(pruned["2026-07-04"] != nil, "Today survives pruning")
+        XCTAssertTrue(pruned["2026-06-05"] != nil, "Days inside the window survive")
+        XCTAssertTrue(pruned["2026-06-01"] == nil, "Days outside the window are pruned")
+        XCTAssertTrue(pruned["2020-01-01"] == nil, "Ancient days are pruned")
+    }
+
+    @Test func testDailyStatsRecordingAndMerge() {
+        var day = DailyStats()
+        day.recordSessionStarted(source: .claudeCode)
+        day.recordSessionStarted(source: .claudeCode)
+        day.recordSessionStarted(source: .codexCli)
+        day.recordApprovalResolution(.accepted)
+        day.recordApprovalResolution(.declined)
+        day.recordApprovalResolution(.cancelled)
+        day.recordApprovalResolution(.timedOut)
+
+        XCTAssertEqual(day.sessionsStartedTotal, 3, "Started sessions sum across sources")
+        XCTAssertEqual(day.sessionsStarted["claudeCode"], 2, "Per-source counts accumulate")
+        XCTAssertEqual(day.approvalsAccepted, 1, "Accepted resolutions count")
+        XCTAssertEqual(day.approvalsDeclined, 1, "Declined resolutions count")
+        XCTAssertEqual(day.approvalsCancelled, 1, "Cancelled resolutions count")
+
+        var other = DailyStats()
+        other.recordSessionStarted(source: .claudeCode)
+        other.tokens = 500
+        other.estimatedCostUSD = 0.5
+        day.merge(other)
+        XCTAssertEqual(day.sessionsStarted["claudeCode"], 3, "Merge adds per-source counts")
+        XCTAssertEqual(day.tokens, 500, "Merge adds tokens")
+    }
+
+    @Test func testUsageDeltaHandlesGrowthResetAndNil() {
+        let previous = UsageSnapshot(lastTokens: 100, totalTokens: 1_000, contextWindow: 0, estimatedCostUSD: 1.0)
+        let grown = UsageSnapshot(lastTokens: 200, totalTokens: 1_500, contextWindow: 0, estimatedCostUSD: 1.4)
+        let growth = UsageStatsPolicy.usageDelta(previous: previous, current: grown)
+        XCTAssertEqual(growth.tokens, 500, "Growth records the positive delta")
+        XCTAssertTrue(abs(growth.costUSD - 0.4) < 1e-9, "Cost delta follows the same rule")
+
+        let first = UsageStatsPolicy.usageDelta(previous: nil, current: previous)
+        XCTAssertEqual(first.tokens, 1_000, "First observation counts the full total")
+
+        let reset = UsageSnapshot(lastTokens: 50, totalTokens: 200, contextWindow: 0, estimatedCostUSD: 0.1)
+        let afterReset = UsageStatsPolicy.usageDelta(previous: previous, current: reset)
+        XCTAssertEqual(afterReset.tokens, 200, "A reset restarts from the new total")
+
+        let none = UsageStatsPolicy.usageDelta(previous: previous, current: nil)
+        XCTAssertEqual(none.tokens, 0, "Missing current usage records nothing")
+    }
+
+    @Test @MainActor func testStoreRoundTripAndClear() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vibelsland-stats-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("stats.json")
+
+        let store = UsageStatsStore(url: url)
+        store.record { day in
+            day.recordSessionStarted(source: .claudeCode)
+            day.tokens += 1_234
+        }
+        store.record { $0.recordApprovalResolution(.accepted) }
+        store.flush()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path), "Flush writes the stats file")
+
+        let reloaded = UsageStatsStore(url: url)
+        XCTAssertEqual(reloaded.todayStats().sessionsStartedTotal, 1, "Counts survive a reload")
+        XCTAssertEqual(reloaded.todayStats().tokens, 1_234, "Tokens survive a reload")
+        XCTAssertEqual(reloaded.todayStats().approvalsAccepted, 1, "Approval counts survive a reload")
+        XCTAssertEqual(reloaded.weekStats().tokens, 1_234, "Week totals include today")
+
+        reloaded.clearAll()
+        XCTAssertEqual(reloaded.todayStats().sessionsStartedTotal, 0, "Clear resets counters")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path), "Clear removes the file")
+    }
+}


### PR DESCRIPTION
## 概要

设置页新增「统计」卡片：今日 / 近 7 天的会话数、完成数、审批结果（✓/✕）、token 合计与成本估算，外加每日 token 迷你条形图。

## 隐私设计

- **只有聚合计数**——不含提示词、命令、路径或任何会话内容。
- 存 `Application Support/VibelslandFree/stats.json`，保留 30 天，卡片上一键清除。
- PRIVACY.md 已同步声明。

## 实现

- `DailyStats` / `UsageStatsPolicy`（日键、7 天窗口、30 天裁剪、增量计算）+ `UsageStatsStore`（2 秒去抖原子写，退出时 flush）。
- 记录挂在会话 upsert 漏斗上做**转移检测**（新会话 / done / failed / 新审批 id / 正向用量增量），Codex 刷新循环的重复回放不会重复计数；token 累计回退（会话重置）时按新值重新起算。

## 验证

- 独立进程断言 10 项全过（含 JST 时区日界、跨年边界、裁剪窗口、增量语义）。
- **端到端**：隔离 HOME 启动真实 App、桥接注入 3 个审批事件 → stats.json 落盘 `approvalsReceived: 3`、`sessionsStarted.claudeCode: 3`。
- Swift Testing 含临时文件的 store 往返用例（CI 执行）。

## 合并顺序

堆叠 PR 链第 **8/9** 个，base 为 `feat/universal-binary`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)