### PR TITLE
feat: add Homebrew cask with release-metadata generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 
+- Added Homebrew Cask support: the repository doubles as a tap (`brew tap shinteni/island https://github.com/shinteni/prompt-island.git && brew install --cask shinteni/island/vibelsland-free`); the cask is generated from docs/release.json and verify-cask.sh gates version/SHA-256 consistency.
 - Added a local statistics card in settings: today/last-7-days session, approval, and token/cost counters with a per-day token mini chart. Counters are aggregate-only (no session content), stay on this Mac, keep 30 days, and can be cleared anytime.
 - Release packaging now builds a Universal Binary (Apple Silicon + Intel): each architecture compiles separately and merges via lipo so the flow works without full Xcode, and build/verify scripts assert both slices are present. Applies from the next release; the published v0.1.0 package remains arm64-only.
 - Reduced background wakeups: the Codex Desktop poller now self-schedules at its adaptive cadence instead of ticking every second, session-aging refresh only wakes at actual visibility boundaries (and not at all when idle and collapsed), and the expanded island's mouse-leave auto-collapse is driven by tracking-area events instead of a 0.22s mouse poll. Refresh rates and collapse timing are unchanged.

--- a/Casks/vibelsland-free.rb
+++ b/Casks/vibelsland-free.rb
@@ -1,0 +1,28 @@
+cask "vibelsland-free" do
+  version "0.1.0"
+  sha256 "b8ae6ea245d4720c1c9389c2ce95a582df9005866fda3522279058eb40b40af5"
+
+  url "https://github.com/shinteni/prompt-island/releases/download/v#{version}/Vibelsland-Free-#{version}-macos.zip"
+  name "Vibelsland Free"
+  desc "Local-first floating island showing Claude Code and Codex session status"
+  homepage "https://shinteni.github.io/prompt-island/"
+
+  depends_on macos: :sonoma
+  depends_on arch: :arm64
+
+  app ">_ - island.app"
+
+  uninstall quit: "free.vibelsland.macos"
+
+  zap trash: [
+    "~/.vibelsland-free",
+    "~/Library/Application Support/VibelslandFree",
+    "~/Library/Logs/VibelslandFree",
+  ]
+
+  caveats <<~EOS
+    Vibelsland Free 0.1.0 is ad-hoc signed and not notarized, so macOS
+    Gatekeeper asks for manual confirmation on first launch. Steps:
+    https://shinteni.github.io/prompt-island/install.html
+  EOS
+end

--- a/README.en.md
+++ b/README.en.md
@@ -92,6 +92,13 @@ Install:
 3. Open the app and install Hooks from the menu bar or settings window.
 4. Configure launch at login, sound, Do Not Disturb, and display position as needed.
 
+Or install with Homebrew (this repository doubles as a tap; the cask version and SHA-256 are generated from `docs/release.json`):
+
+```sh
+brew tap shinteni/island https://github.com/shinteni/prompt-island.git
+brew install --cask shinteni/island/vibelsland-free
+```
+
 Note: the current free release uses ad-hoc codesign, so first launch requires the Gatekeeper confirmation above. Developer ID signing and notarization can reduce first-launch friction in a future distribution path, but the current v0.1.0 download, checksum, source, and install notes are public.
 
 ## Privacy

--- a/README.ja.md
+++ b/README.ja.md
@@ -92,6 +92,13 @@ shasum -a 256 -c Vibelsland-Free-0.1.0-macos.zip.sha256
 3. アプリを開き、メニューバーまたは設定画面から Hooks をインストールします。
 4. 必要に応じてログイン時起動、サウンド、おやすみモード、表示位置を設定します。
 
+Homebrew でもインストールできます（このリポジトリは tap を兼ねており、cask のバージョンと SHA-256 は `docs/release.json` から生成されます）:
+
+```sh
+brew tap shinteni/island https://github.com/shinteni/prompt-island.git
+brew install --cask shinteni/island/vibelsland-free
+```
+
 注記：現在の無料リリースは ad-hoc codesign を使用しているため、初回起動時に Gatekeeper の確認が必要です。Developer ID 署名と notarization は今後の配布改善として対応できますが、現在の v0.1.0 はダウンロード、チェックサム、ソース、インストール手順を公開しています。
 
 ## プライバシー

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ b8ae6ea245d4720c1c9389c2ce95a582df9005866fda3522279058eb40b40af5
 3. 打开应用，在菜单栏或设置页安装 Hooks。
 4. 按需开启自动启动、声音、勿扰和显示位置。
 
+也可以用 Homebrew 安装（本仓库同时是一个 tap，cask 的版本与 SHA-256 由 `docs/release.json` 生成保证一致）：
+
+```sh
+brew tap shinteni/island https://github.com/shinteni/prompt-island.git
+brew install --cask shinteni/island/vibelsland-free
+```
+
 说明：当前免费发布包使用 ad-hoc codesign，首次打开需要按 Gatekeeper 说明手动确认。Developer ID 签名和 notarization 可以作为后续降低首次打开摩擦的分发改进，但当前 v0.1.0 下载、校验、源码和安装说明已经公开。
 
 ## 隐私

--- a/scripts/generate-cask.sh
+++ b/scripts/generate-cask.sh
@@ -1,0 +1,78 @@
+#!/bin/zsh
+set -euo pipefail
+
+# 从 docs/release.json 生成 Homebrew Cask，保证版本号、下载地址与 SHA-256
+# 始终和发布元数据一致。发布新版本后重新运行本脚本并提交生成结果。
+# 输出路径可用第一个参数覆盖（verify-cask.sh 用它生成到临时目录做 diff）。
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RELEASE_METADATA="$ROOT/docs/release.json"
+OUTPUT="${1:-$ROOT/Casks/vibelsland-free.rb}"
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+python3 - "$RELEASE_METADATA" "$OUTPUT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+metadata = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+output = Path(sys.argv[2])
+
+version = metadata["version"]
+sha256 = metadata["archive"]["sha256"]
+archive_name = metadata["archive"]["name"]
+bundle_name = metadata["app"]["bundle_name"]
+bundle_id = metadata["app"]["bundle_identifier"]
+architecture = metadata["platform"]["architecture"]
+signing = metadata["distribution"]["signing"]
+
+url_template = (
+    "https://github.com/shinteni/prompt-island/releases/download/"
+    f"v#{{version}}/{archive_name.replace(version, '#{version}')}"
+)
+
+lines = [
+    'cask "vibelsland-free" do',
+    f'  version "{version}"',
+    f'  sha256 "{sha256}"',
+    "",
+    f'  url "{url_template}"',
+    '  name "Vibelsland Free"',
+    '  desc "Local-first floating island showing Claude Code and Codex session status"',
+    '  homepage "https://shinteni.github.io/prompt-island/"',
+    "",
+    "  depends_on macos: :sonoma",
+]
+
+if architecture == "arm64":
+    lines.append("  depends_on arch: :arm64")
+
+lines += [
+    "",
+    f'  app "{bundle_name}"',
+    "",
+    f'  uninstall quit: "{bundle_id}"',
+    "",
+    "  zap trash: [",
+    '    "~/.vibelsland-free",',
+    '    "~/Library/Application Support/VibelslandFree",',
+    '    "~/Library/Logs/VibelslandFree",',
+    "  ]",
+]
+
+if signing == "ad-hoc":
+    lines += [
+        "",
+        "  caveats <<~EOS",
+        f"    Vibelsland Free {version} is ad-hoc signed and not notarized, so macOS",
+        "    Gatekeeper asks for manual confirmation on first launch. Steps:",
+        "    https://shinteni.github.io/prompt-island/install.html",
+        "  EOS",
+    ]
+
+lines += ["end", ""]
+
+output.write_text("\n".join(lines), encoding="utf-8")
+print(output)
+PY

--- a/scripts/verify-cask.sh
+++ b/scripts/verify-cask.sh
@@ -1,0 +1,32 @@
+#!/bin/zsh
+set -euo pipefail
+
+# Cask 一致性校验：
+# 1. 提交的 Casks/vibelsland-free.rb 必须与 docs/release.json 重新生成的结果逐字一致；
+# 2. Ruby 语法有效；
+# 3. sha256 与发布元数据一致（由 1 隐含，这里再显式核对一次防御生成器缺陷）。
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CASK="$ROOT/Casks/vibelsland-free.rb"
+RELEASE_METADATA="$ROOT/docs/release.json"
+
+[[ -f "$CASK" ]]
+
+TMP_DIR="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/vibelsland-cask.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+zsh "$ROOT/scripts/generate-cask.sh" "$TMP_DIR/vibelsland-free.rb" >/dev/null
+if ! /usr/bin/diff -u "$CASK" "$TMP_DIR/vibelsland-free.rb"; then
+    echo "verify-cask: Casks/vibelsland-free.rb is out of sync with docs/release.json; run scripts/generate-cask.sh" >&2
+    exit 1
+fi
+
+/usr/bin/ruby -c "$CASK" >/dev/null
+
+EXPECTED_SHA="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['archive']['sha256'])" "$RELEASE_METADATA")"
+if ! /usr/bin/grep -q "sha256 \"$EXPECTED_SHA\"" "$CASK"; then
+    echo "verify-cask: sha256 in cask does not match docs/release.json" >&2
+    exit 1
+fi
+
+echo "Cask verification passed"


### PR DESCRIPTION
## 概要

仓库本身兼作 Homebrew tap，新增安装方式：

```sh
brew tap shinteni/island https://github.com/shinteni/prompt-island.git
brew install --cask shinteni/island/vibelsland-free
```

## 一致性保障（延续本项目发布闭环风格）

- `Casks/vibelsland-free.rb` 由 `scripts/generate-cask.sh` 从 `docs/release.json` 生成：版本、下载地址、SHA-256、架构要求、ad-hoc 签名 caveat 全部来自发布元数据单一事实来源。
- `scripts/verify-cask.sh` 做逐字 diff + ruby 语法 + sha256 显式核对，cask 与元数据失同步会直接失败。
- 三语 README 安装节同步补充 brew 方式。

## 验证

- 真实 `brew tap`（本地 file:// URL）→ `brew info --cask` 正确解析出版本 0.1.0、arm64 + macOS ≥ 14 要求与 artifacts，随后 untap 清理。
- 过程中发现并修复了 `depends_on macos: ">= :sonoma"` 字符串格式的 brew 弃用警告（改为符号形式）。
- `verify-docs-site.sh` 通过（README 改动不破坏文档校验）。

## 合并顺序

堆叠 PR 链第 **9/9** 个（最后合并），base 为 `feat/stats-panel`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)