### PR TITLE
feat: polish island motion and interaction feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 
+- Polished island motion and interaction feedback: the expand/collapse frame animation is now display-link driven (full frame rate on ProMotion) with a snappier ease-out expansion curve, content crossfades gain subtle depth scaling, approval cards spring in and out, and every clickable island element gets hover highlighting with a pointing-hand cursor plus press feedback. The system Reduce Motion setting disables all scaling and transitions.
 - Added Homebrew Cask support: the repository doubles as a tap (`brew tap shinteni/island https://github.com/shinteni/prompt-island.git && brew install --cask shinteni/island/vibelsland-free`); the cask is generated from docs/release.json and verify-cask.sh gates version/SHA-256 consistency.
 - Added a local statistics card in settings: today/last-7-days session, approval, and token/cost counters with a per-day token mini chart. Counters are aggregate-only (no session content), stay on this Mac, keep 30 days, and can be cleared anytime.
 - Release packaging now builds a Universal Binary (Apple Silicon + Intel): each architecture compiles separately and merges via lipo so the flow works without full Xcode, and build/verify scripts assert both slices are present. Applies from the next release; the published v0.1.0 package remains arm64-only.

--- a/Sources/VibelslandFree/IslandApprovalViews.swift
+++ b/Sources/VibelslandFree/IslandApprovalViews.swift
@@ -59,6 +59,7 @@ struct ApprovalSummaryCard: View {
                 .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             }
             .buttonStyle(.plain)
+            .islandHoverHighlight(scale: 1.0)
             .help(AppText.pick(configurationStore.config.language, english: "View approval details", japanese: "承認詳細を表示", chinese: "查看审批详情"))
 
             HStack(spacing: 4) {
@@ -76,7 +77,8 @@ struct ApprovalSummaryCard: View {
                     showsDetail = true
                 }
                 .font(.system(size: 12, weight: .semibold))
-                .buttonStyle(.plain)
+                .buttonStyle(PressableButtonStyle())
+                .islandHoverHighlight(scale: 1.0)
                 .foregroundStyle(GlassText.secondary)
                 .disabled(approval.isResolving || approval.isExpired)
             }
@@ -101,24 +103,28 @@ struct ApprovalSummaryCard: View {
     }
 
     private func approvalButton(_ title: String, _ decision: ApprovalDecision, prominent: Bool = false) -> some View {
-        Button(title) {
+        Button {
             store.resolveApproval(approval, decision: decision)
+        } label: {
+            // 视觉层放在 label 内，按压缩放才会作用于整个胶囊而不是只有文字。
+            Text(title)
+                .font(.system(size: 12, weight: .semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+                .padding(.horizontal, 8)
+                .frame(height: 26)
+                .background(
+                    ClearGlassCapsuleBackground(
+                        highlighted: prominent,
+                        tint: prominent ? Color.white.opacity(0.16) : Color.white.opacity(0.030),
+                        materialOpacity: prominent ? 0.62 : 0.42
+                    )
+                )
+                .foregroundStyle(prominent ? Color(red: 0.12, green: 0.42, blue: 0.84) : GlassText.primary)
+                .clipShape(Capsule())
         }
-        .font(.system(size: 12, weight: .semibold))
-        .lineLimit(1)
-        .minimumScaleFactor(0.82)
-        .padding(.horizontal, 8)
-        .frame(height: 26)
-        .background(
-            ClearGlassCapsuleBackground(
-                highlighted: prominent,
-                tint: prominent ? Color.white.opacity(0.16) : Color.white.opacity(0.030),
-                materialOpacity: prominent ? 0.62 : 0.42
-            )
-        )
-        .foregroundStyle(prominent ? Color(red: 0.12, green: 0.42, blue: 0.84) : GlassText.primary)
-        .clipShape(Capsule())
-        .buttonStyle(.plain)
+        .buttonStyle(PressableButtonStyle())
+        .islandHoverHighlight()
         .disabled(approval.isResolving || approval.isExpired)
     }
 
@@ -229,6 +235,7 @@ private struct ApprovalQueueRow: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .islandHoverHighlight(scale: 1.0)
             .help(AppText.pick(configurationStore.config.language, english: "View approval details", japanese: "承認詳細を表示", chinese: "查看审批详情"))
 
             if approval.supports(.accept) {
@@ -242,24 +249,27 @@ private struct ApprovalQueueRow: View {
     }
 
     private func queueActionButton(_ title: String, _ decision: ApprovalDecision, prominent: Bool = false) -> some View {
-        Button(title) {
+        Button {
             store.resolveApproval(approval, decision: decision)
+        } label: {
+            Text(title)
+                .font(.system(size: 11, weight: .semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+                .padding(.horizontal, 8)
+                .frame(height: 24)
+                .background(
+                    ClearGlassCapsuleBackground(
+                        highlighted: prominent,
+                        tint: prominent ? Color.white.opacity(0.16) : Color.white.opacity(0.030),
+                        materialOpacity: prominent ? 0.62 : 0.42
+                    )
+                )
+                .foregroundStyle(prominent ? Color(red: 0.12, green: 0.42, blue: 0.84) : GlassText.primary)
+                .clipShape(Capsule())
         }
-        .font(.system(size: 11, weight: .semibold))
-        .lineLimit(1)
-        .minimumScaleFactor(0.82)
-        .padding(.horizontal, 8)
-        .frame(height: 24)
-        .background(
-            ClearGlassCapsuleBackground(
-                highlighted: prominent,
-                tint: prominent ? Color.white.opacity(0.16) : Color.white.opacity(0.030),
-                materialOpacity: prominent ? 0.62 : 0.42
-            )
-        )
-        .foregroundStyle(prominent ? Color(red: 0.12, green: 0.42, blue: 0.84) : GlassText.primary)
-        .clipShape(Capsule())
-        .buttonStyle(.plain)
+        .buttonStyle(PressableButtonStyle())
+        .islandHoverHighlight()
         .disabled(approval.isResolving || approval.isExpired)
     }
 
@@ -355,22 +365,25 @@ struct ApprovalDetailCard: View {
     }
 
     private func approvalButton(_ decision: ApprovalDecision, prominent: Bool = false) -> some View {
-        Button(decision.title(language: configurationStore.config.language)) {
+        Button {
             store.resolveApproval(approval, decision: decision)
+        } label: {
+            Text(decision.title(language: configurationStore.config.language))
+                .font(.system(size: 12, weight: .semibold))
+                .padding(.horizontal, 10)
+                .frame(height: 28)
+                .background(
+                    ClearGlassCapsuleBackground(
+                        highlighted: prominent,
+                        tint: prominent ? Color.white.opacity(0.16) : Color.white.opacity(0.030),
+                        materialOpacity: prominent ? 0.62 : 0.42
+                    )
+                )
+                .foregroundStyle(prominent ? Color(red: 0.12, green: 0.42, blue: 0.84) : GlassText.primary)
+                .clipShape(Capsule())
         }
-        .font(.system(size: 12, weight: .semibold))
-        .padding(.horizontal, 10)
-        .frame(height: 28)
-        .background(
-            ClearGlassCapsuleBackground(
-                highlighted: prominent,
-                tint: prominent ? Color.white.opacity(0.16) : Color.white.opacity(0.030),
-                materialOpacity: prominent ? 0.62 : 0.42
-            )
-        )
-        .foregroundStyle(prominent ? Color(red: 0.12, green: 0.42, blue: 0.84) : GlassText.primary)
-        .clipShape(Capsule())
-        .buttonStyle(.plain)
+        .buttonStyle(PressableButtonStyle())
+        .islandHoverHighlight()
         .disabled(approval.isResolving || approval.isExpired)
     }
 

--- a/Sources/VibelslandFree/IslandDashboardViews.swift
+++ b/Sources/VibelslandFree/IslandDashboardViews.swift
@@ -102,6 +102,7 @@ struct HealthSummaryStrip: View {
             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         }
         .buttonStyle(.plain)
+        .islandHoverHighlight(scale: 1.0)
         .help(AppText.pick(configurationStore.config.language, english: "Open health checks", japanese: "ヘルスチェックを開く", chinese: "打开健康检查"))
     }
 
@@ -218,6 +219,7 @@ struct DashboardSessionCard: View {
             }
         )
         .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .islandHoverHighlight(scale: 1.004)
         .help(session.source == .unknown ? AppText.pick(configurationStore.config.language, english: "Select session", japanese: "セッションを選択", chinese: "选中会话") : AppText.pick(configurationStore.config.language, english: "Open \(session.source.displayName)", japanese: "\(session.source.displayName) を開く", chinese: "打开 \(session.source.displayName)"))
         .accessibilityLabel("\(display.title)，\(display.primaryLine)，\(display.secondaryLine ?? "")")
     }

--- a/Sources/VibelslandFree/IslandMotion.swift
+++ b/Sources/VibelslandFree/IslandMotion.swift
@@ -2,8 +2,22 @@ import SwiftUI
 import VibelslandFreeCore
 
 enum IslandMotion {
-    static let expansionSpring = Animation.spring(response: 0.32, dampingFraction: 0.86)
     static let contentCrossfade = Animation.easeInOut(duration: IslandMotionPolicy.ContentTransition.crossfadeDuration)
+
+    /// Reduce Motion 时返回 nil（不做动画，直接切换）。
+    static func contentCrossfade(reduceMotion: Bool) -> Animation? {
+        reduceMotion ? nil : contentCrossfade
+    }
+
+    /// 审批卡片进出场：轻快弹簧，落定不晃。
+    static let approvalCardSpring = Animation.spring(response: 0.34, dampingFraction: 0.84)
+
+    static func approvalCardSpring(reduceMotion: Bool) -> Animation? {
+        reduceMotion ? nil : approvalCardSpring
+    }
+
+    static let hoverEase = Animation.easeOut(duration: IslandMotionPolicy.InteractionFeedback.hoverDuration)
+    static let pressEase = Animation.easeOut(duration: IslandMotionPolicy.InteractionFeedback.pressDuration)
 
     enum MiniProgressRing {
         static func refreshInterval(for status: SessionStatus) -> TimeInterval {

--- a/Sources/VibelslandFree/IslandPanelView.swift
+++ b/Sources/VibelslandFree/IslandPanelView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct IslandPanelView: View {
     @EnvironmentObject private var store: SessionStore
     @EnvironmentObject private var configurationStore: AppConfigurationStore
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var showingApprovalDetail = false
     @State private var contentPresentationExpanded = false
     @State private var showExpandedContentLayer = false
@@ -20,17 +21,29 @@ struct IslandPanelView: View {
 
             ZStack {
                 if showsExpandedLayer {
+                    // 交叉淡化叠加细微缩放：展开内容从 0.98 生长到位，读作形变而非替换。
                     expandedContent
                         .opacity(contentPresentationExpanded ? 1 : 0)
+                        .scaleEffect(
+                            reduceMotion || contentPresentationExpanded
+                                ? 1
+                                : IslandMotionPolicy.ContentTransition.expandedLayerInitialScale,
+                            anchor: .top
+                        )
                         .allowsHitTesting(contentPresentationExpanded)
                 }
                 if showsCompactLayer {
                     compactContent
                         .opacity(contentPresentationExpanded ? 0 : 1)
+                        .scaleEffect(
+                            !reduceMotion && contentPresentationExpanded
+                                ? IslandMotionPolicy.ContentTransition.compactLayerLiftedScale
+                                : 1
+                        )
                         .allowsHitTesting(!contentPresentationExpanded)
                 }
             }
-            .animation(IslandMotion.contentCrossfade, value: contentPresentationExpanded)
+            .animation(IslandMotion.contentCrossfade(reduceMotion: reduceMotion), value: contentPresentationExpanded)
             .zIndex(1)
         }
         .background(Color.clear)
@@ -77,7 +90,7 @@ struct IslandPanelView: View {
             let transitionID = contentTransitionID
             showExpandedContentLayer = true
             showCompactContentLayer = true
-            withAnimation(IslandMotion.contentCrossfade) {
+            withAnimation(IslandMotion.contentCrossfade(reduceMotion: reduceMotion)) {
                 contentPresentationExpanded = isExpanded
             }
             DispatchQueue.main.asyncAfter(
@@ -224,6 +237,7 @@ struct IslandPanelView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .contentShape(Rectangle())
+        .islandHoverHighlight(scale: 1.01)
         .onTapGesture {
             guard !store.shouldSuppressCompactTap() else { return }
             NSApp.activate(ignoringOtherApps: true)
@@ -253,28 +267,38 @@ struct IslandPanelView: View {
                 HealthSummaryStrip(items: store.healthChecks)
             }
 
-            if showingApprovalDetail,
-               let approvalSession = approvalDetailSession,
-               let approval = approvalSession.approval {
-                ApprovalDetailCard(session: approvalSession, approval: approval) {
-                    showingApprovalDetail = false
+            // 审批区的摘要/队列/详情三态切换用轻弹簧 + 缩放过渡，新审批到达时卡片「生长」出现。
+            Group {
+                if showingApprovalDetail,
+                   let approvalSession = approvalDetailSession,
+                   let approval = approvalSession.approval {
+                    ApprovalDetailCard(session: approvalSession, approval: approval) {
+                        showingApprovalDetail = false
+                    }
+                    .environmentObject(store)
+                    .transition(approvalCardTransition)
+                } else if approvalQueueSessions.count > 1 {
+                    ApprovalQueueCard(sessions: approvalQueueSessions) { session in
+                        store.selectedSessionID = session.id
+                        showingApprovalDetail = true
+                    }
+                    .environmentObject(store)
+                    .transition(approvalCardTransition)
+                } else if let approvalSession = approvalQueueSessions.first,
+                          let approval = approvalSession.approval {
+                    ApprovalSummaryCard(
+                        session: approvalSession,
+                        approval: approval,
+                        showsDetail: $showingApprovalDetail
+                    )
+                    .environmentObject(store)
+                    .transition(approvalCardTransition)
                 }
-                .environmentObject(store)
-            } else if approvalQueueSessions.count > 1 {
-                ApprovalQueueCard(sessions: approvalQueueSessions) { session in
-                    store.selectedSessionID = session.id
-                    showingApprovalDetail = true
-                }
-                .environmentObject(store)
-            } else if let approvalSession = approvalQueueSessions.first,
-                      let approval = approvalSession.approval {
-                ApprovalSummaryCard(
-                    session: approvalSession,
-                    approval: approval,
-                    showsDetail: $showingApprovalDetail
-                )
-                .environmentObject(store)
             }
+            .animation(
+                IslandMotion.approvalCardSpring(reduceMotion: reduceMotion),
+                value: approvalAreaSignature
+            )
 
             if showingApprovalDetail && approvalDetailSession != nil {
                 EmptyView()
@@ -312,6 +336,7 @@ struct IslandPanelView: View {
                     UsageHeaderView(usage: usage)
                 }
                 .buttonStyle(.plain)
+                .islandHoverHighlight(scale: 1.0)
                 .help(AppText.pick(configurationStore.config.language, english: "Open usage settings", japanese: "使用量設定を開く", chinese: "查看用量设置"))
             } else {
                 Button {
@@ -322,6 +347,7 @@ struct IslandPanelView: View {
                         .foregroundStyle(GlassText.primary)
                 }
                 .buttonStyle(.plain)
+                .islandHoverHighlight(scale: 1.0)
                 .help(AppText.pick(configurationStore.config.language, english: "Open settings", japanese: "設定を開く", chinese: "打开设置"))
             }
             Spacer()
@@ -493,6 +519,17 @@ struct IslandPanelView: View {
 
     private var quitTitle: String {
         AppText.pick(configurationStore.config.language, english: "Quit app", japanese: "アプリを終了", chinese: "退出应用")
+    }
+
+    private var approvalCardTransition: AnyTransition {
+        reduceMotion
+            ? .opacity
+            : .opacity.combined(with: .scale(scale: 0.97, anchor: .top))
+    }
+
+    /// 审批区状态签名：详情开关 + 队列成员变化都触发弹簧过渡。
+    private var approvalAreaSignature: String {
+        "\(showingApprovalDetail)|\(approvalQueueSessions.map(\.id).joined(separator: ","))"
     }
 
     private var pendingApprovalSession: AgentSession? {

--- a/Sources/VibelslandFree/IslandVisualStyle.swift
+++ b/Sources/VibelslandFree/IslandVisualStyle.swift
@@ -295,6 +295,10 @@ struct PressableButtonStyle: ButtonStyle {
 
 /// 悬停高亮：轻微放大 + 提亮 + 小手光标，让可点元素在悬停时有明确的可点感。
 /// Reduce Motion 时跳过缩放，保留提亮与光标。
+///
+/// 不用 SwiftUI 的 .onHover：它的 tracking area 只在应用激活时生效，而浮岛是
+/// 常驻辅助面板，用户悬停时应用几乎总是非激活的。这里用 .activeAlways 的
+/// 显式 NSTrackingArea（与浮岛离开自动收起相同的机制）保证任何状态都有反馈。
 struct IslandHoverHighlight: ViewModifier {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isHovering = false
@@ -306,24 +310,72 @@ struct IslandHoverHighlight: ViewModifier {
             .scaleEffect(isHovering && !reduceMotion ? scale : 1)
             .brightness(isHovering ? IslandMotionPolicy.InteractionFeedback.hoverBrightness : 0)
             .animation(IslandMotion.hoverEase, value: isHovering)
-            .onHover { hovering in
-                guard hovering != isHovering else { return }
-                isHovering = hovering
-                guard usesPointingHand else { return }
-                if hovering {
-                    NSCursor.pointingHand.push()
-                } else {
-                    NSCursor.pop()
+            .overlay(
+                AlwaysOnHoverView(usesPointingHand: usesPointingHand) { hovering in
+                    isHovering = hovering
                 }
-            }
+            )
             .onDisappear {
                 if isHovering {
                     if usesPointingHand {
-                        NSCursor.pop()
+                        NSCursor.arrow.set()
                     }
                     isHovering = false
                 }
             }
+    }
+}
+
+/// 应用非激活时也能收到进出事件的悬停探测层；对点击完全透明。
+private struct AlwaysOnHoverView: NSViewRepresentable {
+    let usesPointingHand: Bool
+    let onHoverChanged: (Bool) -> Void
+
+    func makeNSView(context: Context) -> TrackingView {
+        let view = TrackingView()
+        view.usesPointingHand = usesPointingHand
+        view.onHoverChanged = onHoverChanged
+        return view
+    }
+
+    func updateNSView(_ view: TrackingView, context: Context) {
+        view.usesPointingHand = usesPointingHand
+        view.onHoverChanged = onHoverChanged
+    }
+
+    final class TrackingView: NSView {
+        var usesPointingHand = true
+        var onHoverChanged: ((Bool) -> Void)?
+
+        override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            for area in trackingAreas {
+                removeTrackingArea(area)
+            }
+            addTrackingArea(NSTrackingArea(
+                rect: .zero,
+                options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+                owner: self,
+                userInfo: nil
+            ))
+        }
+
+        // 悬停探测不拦截任何鼠标事件，点击照常落到下面的按钮/手势上。
+        override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+        override func mouseEntered(with event: NSEvent) {
+            onHoverChanged?(true)
+            if usesPointingHand {
+                NSCursor.pointingHand.set()
+            }
+        }
+
+        override func mouseExited(with event: NSEvent) {
+            onHoverChanged?(false)
+            if usesPointingHand {
+                NSCursor.arrow.set()
+            }
+        }
     }
 }
 

--- a/Sources/VibelslandFree/IslandVisualStyle.swift
+++ b/Sources/VibelslandFree/IslandVisualStyle.swift
@@ -276,7 +276,69 @@ struct DashboardRowBackground: View {
     }
 }
 
+/// 胶囊/卡片操作的按压反馈：轻微缩放 + 变淡。Reduce Motion 时不缩放，只保留不透明度变化。
+struct PressableButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    var pressedScale: CGFloat = IslandMotionPolicy.InteractionFeedback.pressedScale
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(
+                configuration.isPressed
+                    ? IslandMotionPolicy.InteractionFeedback.pressedScale(pressedScale, reduceMotion: reduceMotion)
+                    : 1
+            )
+            .opacity(configuration.isPressed ? IslandMotionPolicy.InteractionFeedback.pressedOpacity : 1)
+            .animation(IslandMotion.pressEase, value: configuration.isPressed)
+    }
+}
+
+/// 悬停高亮：轻微放大 + 提亮 + 小手光标，让可点元素在悬停时有明确的可点感。
+/// Reduce Motion 时跳过缩放，保留提亮与光标。
+struct IslandHoverHighlight: ViewModifier {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isHovering = false
+    var scale: CGFloat = IslandMotionPolicy.InteractionFeedback.hoverScale
+    var usesPointingHand = true
+
+    func body(content: Content) -> some View {
+        content
+            .scaleEffect(isHovering && !reduceMotion ? scale : 1)
+            .brightness(isHovering ? IslandMotionPolicy.InteractionFeedback.hoverBrightness : 0)
+            .animation(IslandMotion.hoverEase, value: isHovering)
+            .onHover { hovering in
+                guard hovering != isHovering else { return }
+                isHovering = hovering
+                guard usesPointingHand else { return }
+                if hovering {
+                    NSCursor.pointingHand.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+            .onDisappear {
+                if isHovering {
+                    if usesPointingHand {
+                        NSCursor.pop()
+                    }
+                    isHovering = false
+                }
+            }
+    }
+}
+
+extension View {
+    func islandHoverHighlight(
+        scale: CGFloat = IslandMotionPolicy.InteractionFeedback.hoverScale,
+        usesPointingHand: Bool = true
+    ) -> some View {
+        modifier(IslandHoverHighlight(scale: scale, usesPointingHand: usesPointingHand))
+    }
+}
+
 struct DashboardIconButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.system(size: 15, weight: .bold))
@@ -290,10 +352,18 @@ struct DashboardIconButtonStyle: ButtonStyle {
                     materialOpacity: configuration.isPressed ? 0.48 : 0.34
                 )
             )
+            .scaleEffect(
+                configuration.isPressed
+                    ? IslandMotionPolicy.InteractionFeedback.pressedScale(reduceMotion: reduceMotion)
+                    : 1
+            )
+            .animation(IslandMotion.pressEase, value: configuration.isPressed)
     }
 }
 
 struct DashboardSmallButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.system(size: 12, weight: .bold))
@@ -307,6 +377,12 @@ struct DashboardSmallButtonStyle: ButtonStyle {
                     materialOpacity: configuration.isPressed ? 0.48 : 0.32
                 )
             )
+            .scaleEffect(
+                configuration.isPressed
+                    ? IslandMotionPolicy.InteractionFeedback.pressedScale(reduceMotion: reduceMotion)
+                    : 1
+            )
+            .animation(IslandMotion.pressEase, value: configuration.isPressed)
     }
 }
 

--- a/Sources/VibelslandFree/IslandWindow+AutoCollapse.swift
+++ b/Sources/VibelslandFree/IslandWindow+AutoCollapse.swift
@@ -61,8 +61,12 @@ extension IslandWindow {
 
     /// 事件驱动的离开收起：tracking area 的进出事件代替旧的 0.22 秒鼠标轮询。
     /// 鼠标离开（或启动监视时就在窗外）后启动一次性宽限定时器，重新进入即取消。
+    /// 幂等：布局刷新会反复调用这里（applyLayout → updateOutsideClickMonitor），
+    /// 已在监视中时不得重置倒计时，否则周期性刷新会把收起无限推迟。
     private func startAutoCollapseWatch() {
+        let wasActive = autoCollapseWatchActive
         autoCollapseWatchActive = true
+        guard !wasActive else { return }
         if !frame.insetBy(dx: -12, dy: -12).contains(NSEvent.mouseLocation) {
             armAutoCollapseTimer()
         }
@@ -74,17 +78,15 @@ extension IslandWindow {
         autoCollapseTimer = nil
     }
 
-    override func mouseEntered(with event: NSEvent) {
+    func autoCollapseMouseEntered() {
         autoCollapseTimer?.invalidate()
         autoCollapseTimer = nil
-        super.mouseEntered(with: event)
     }
 
-    override func mouseExited(with event: NSEvent) {
+    func autoCollapseMouseExited() {
         if autoCollapseWatchActive {
             armAutoCollapseTimer()
         }
-        super.mouseExited(with: event)
     }
 
     private func armAutoCollapseTimer() {
@@ -113,5 +115,36 @@ extension IslandWindow {
             guard let approval = session.approval else { return false }
             return !approval.isExpired
         }
+    }
+}
+
+/// 覆盖整个浮岛内容区的自愈式进出追踪视图。
+/// 自己的 updateTrackingAreas 每次都重新注册区域，SwiftUI 的 tracking 重建
+/// 清不掉它；对点击完全透明。
+final class WindowHoverTrackingView: NSView {
+    var onEntered: (() -> Void)?
+    var onExited: (() -> Void)?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        for area in trackingAreas {
+            removeTrackingArea(area)
+        }
+        addTrackingArea(NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        ))
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override func mouseEntered(with event: NSEvent) {
+        onEntered?()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        onExited?()
     }
 }

--- a/Sources/VibelslandFree/IslandWindow.swift
+++ b/Sources/VibelslandFree/IslandWindow.swift
@@ -27,6 +27,7 @@ final class IslandWindow: NSPanel {
     private var frameDisplayLink: CADisplayLink?
     private var frameAnimationContext: FrameAnimationContext?
     private var hasPresented = false
+    private weak var swiftUIHostingView: NSView?
 
     private struct FrameAnimationContext {
         let start: NSRect
@@ -75,12 +76,22 @@ final class IslandWindow: NSPanel {
         hostingView.wantsLayer = true
         hostingView.layer?.backgroundColor = NSColor.clear.cgColor
         contentView = hostingView
-        hostingView.addTrackingArea(NSTrackingArea(
-            rect: .zero,
-            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
-            owner: self,
-            userInfo: nil
-        ))
+        swiftUIHostingView = hostingView
+
+        // 自动收起的进出追踪不能直接 addTrackingArea 到 NSHostingView：
+        // SwiftUI 重建自身 tracking areas 时会把外来区域清掉且不会恢复，
+        // 事件随之静默失效。用自愈式追踪视图（每次 updateTrackingAreas 都
+        // 重新注册自己的区域）作为子视图覆盖整个内容区。
+        let tracker = WindowHoverTrackingView()
+        tracker.onEntered = { [weak self] in
+            self?.autoCollapseMouseEntered()
+        }
+        tracker.onExited = { [weak self] in
+            self?.autoCollapseMouseExited()
+        }
+        tracker.frame = hostingView.bounds
+        tracker.autoresizingMask = [.width, .height]
+        hostingView.addSubview(tracker)
 
         observeLayout()
         applyFrame(

--- a/Sources/VibelslandFree/IslandWindow.swift
+++ b/Sources/VibelslandFree/IslandWindow.swift
@@ -27,7 +27,6 @@ final class IslandWindow: NSPanel {
     private var frameDisplayLink: CADisplayLink?
     private var frameAnimationContext: FrameAnimationContext?
     private var hasPresented = false
-    private weak var swiftUIHostingView: NSView?
 
     private struct FrameAnimationContext {
         let start: NSRect
@@ -76,7 +75,6 @@ final class IslandWindow: NSPanel {
         hostingView.wantsLayer = true
         hostingView.layer?.backgroundColor = NSColor.clear.cgColor
         contentView = hostingView
-        swiftUIHostingView = hostingView
 
         // 自动收起的进出追踪不能直接 addTrackingArea 到 NSHostingView：
         // SwiftUI 重建自身 tracking areas 时会把外来区域清掉且不会恢复，

--- a/Sources/VibelslandFree/IslandWindow.swift
+++ b/Sources/VibelslandFree/IslandWindow.swift
@@ -24,8 +24,17 @@ final class IslandWindow: NSPanel {
     private var lastLayoutSignature: IslandLayoutSignature?
     var lastVisibleFrame: NSRect?
     private var transitionResetTask: Task<Void, Never>?
-    private var frameAnimationTimer: Timer?
+    private var frameDisplayLink: CADisplayLink?
+    private var frameAnimationContext: FrameAnimationContext?
     private var hasPresented = false
+
+    private struct FrameAnimationContext {
+        let start: NSRect
+        let target: NSRect
+        let startedAt: CFTimeInterval
+        let duration: TimeInterval
+        let expanded: Bool
+    }
     var hiddenForSystemOverview = false
     var suppressedForSettings = false
     weak var store: SessionStore?
@@ -248,7 +257,11 @@ final class IslandWindow: NSPanel {
             abs(frame.width - target.width) > 0.5 ||
             abs(frame.height - target.height) > 0.5
         let presentationChanged = lastAppliedExpanded != expanded
-        let shouldAnimateFrame = animated && hasPresented && frameWillChange
+        let transitionDuration = IslandMotionPolicy.WindowTransition.duration(
+            expanded: expanded,
+            reduceMotion: NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+        )
+        let shouldAnimateFrame = animated && hasPresented && frameWillChange && transitionDuration > 0
 
         if shouldAnimateFrame {
             store?.isIslandTransitioning = true
@@ -278,7 +291,7 @@ final class IslandWindow: NSPanel {
         }
 
         if shouldAnimateFrame {
-            animateFrame(to: target, duration: IslandMotionPolicy.WindowTransition.duration(expanded: expanded))
+            animateFrame(to: target, duration: transitionDuration, expanded: expanded)
         } else if frameWillChange {
             stopFrameAnimation()
             setFrame(target, display: true)
@@ -308,38 +321,42 @@ final class IslandWindow: NSPanel {
     }
 
     private func stopFrameAnimation() {
-        frameAnimationTimer?.invalidate()
-        frameAnimationTimer = nil
+        frameDisplayLink?.invalidate()
+        frameDisplayLink = nil
+        frameAnimationContext = nil
     }
 
-    private func animateFrame(to target: NSRect, duration: TimeInterval) {
+    /// 帧动画由 CADisplayLink 驱动：跟随显示器实际刷新率（ProMotion 下满 120Hz），
+    /// 替代旧的固定 60Hz Timer；缓动曲线在 IslandMotionPolicy 中按展开/收起区分。
+    private func animateFrame(to target: NSRect, duration: TimeInterval, expanded: Bool) {
         stopFrameAnimation()
-        let start = frame
-        let startedAt = CACurrentMediaTime()
-        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] timer in
-            guard timer.isValid else { return }
-            MainActor.assumeIsolated {
-                self?.stepFrameAnimation(
-                    start: start,
-                    target: target,
-                    startedAt: startedAt,
-                    duration: duration
-                )
-            }
+        guard duration > 0, let contentView else {
+            setFrame(target, display: true)
+            rememberVisibleFrame()
+            return
         }
-        frameAnimationTimer = timer
-        RunLoop.main.add(timer, forMode: .common)
+        frameAnimationContext = FrameAnimationContext(
+            start: frame,
+            target: target,
+            startedAt: CACurrentMediaTime(),
+            duration: duration,
+            expanded: expanded
+        )
+        let link = contentView.displayLink(target: self, selector: #selector(stepFrameDisplayLink(_:)))
+        link.add(to: .main, forMode: .common)
+        frameDisplayLink = link
     }
 
-    private func stepFrameAnimation(
-        start: NSRect,
-        target: NSRect,
-        startedAt: CFTimeInterval,
-        duration: TimeInterval
-    ) {
-        let elapsed = CACurrentMediaTime() - startedAt
-        let progress = min(max(elapsed / max(duration, 0.001), 0), 1)
-        let eased = progress * progress * (3 - 2 * progress)
+    @objc private func stepFrameDisplayLink(_ link: CADisplayLink) {
+        guard let context = frameAnimationContext else {
+            stopFrameAnimation()
+            return
+        }
+        let elapsed = CACurrentMediaTime() - context.startedAt
+        let progress = min(max(elapsed / max(context.duration, 0.001), 0), 1)
+        let eased = IslandMotionPolicy.WindowTransition.easedProgress(progress, expanded: context.expanded)
+        let start = context.start
+        let target = context.target
         let next = NSRect(
             x: start.minX + (target.minX - start.minX) * eased,
             y: start.minY + (target.minY - start.minY) * eased,
@@ -348,8 +365,7 @@ final class IslandWindow: NSPanel {
         )
         setFrame(next, display: true)
         if progress >= 1 {
-            frameAnimationTimer?.invalidate()
-            frameAnimationTimer = nil
+            stopFrameAnimation()
             setFrame(target, display: true)
             rememberVisibleFrame()
         }

--- a/Sources/VibelslandFreeCore/IslandMotionPolicy.swift
+++ b/Sources/VibelslandFreeCore/IslandMotionPolicy.swift
@@ -104,12 +104,54 @@ package enum IslandMotionPolicy {
             expanded ? expansionDuration : collapseDuration
         }
 
+        /// 尊重系统「减弱动态效果」：直接落到目标帧，不做过渡。
+        package static func duration(expanded: Bool, reduceMotion: Bool) -> TimeInterval {
+            reduceMotion ? 0 : duration(expanded: expanded)
+        }
+
         package static func resetDelay(expanded: Bool) -> UInt64 {
             UInt64((duration(expanded: expanded) + resetPadding) * 1_000_000_000)
+        }
+
+        /// 帧动画缓动。展开用 ease-out-cubic：起步快（跟手感），落定柔和；
+        /// 收起保留 smoothstep 的对称节奏，避免收起显得急促。
+        package static func easedProgress(_ progress: Double, expanded: Bool) -> Double {
+            let t = min(max(progress, 0), 1)
+            if expanded {
+                let inverse = 1 - t
+                return 1 - inverse * inverse * inverse
+            }
+            return t * t * (3 - 2 * t)
         }
     }
 
     package enum ContentTransition {
         package static let crossfadeDuration: TimeInterval = 0.18
+        /// 交叉淡化时给两层内容一点纵深缩放，让展开/收起读作「形变」而非「替换」。
+        package static let expandedLayerInitialScale: CGFloat = 0.98
+        package static let compactLayerLiftedScale: CGFloat = 1.03
+
+        package static func crossfadeDuration(reduceMotion: Bool) -> TimeInterval {
+            reduceMotion ? 0 : crossfadeDuration
+        }
+    }
+
+    package enum InteractionFeedback {
+        package static let hoverScale: CGFloat = 1.015
+        package static let pressedScale: CGFloat = 0.97
+        package static let cardPressedScale: CGFloat = 0.985
+        package static let hoverBrightness: Double = 0.05
+        package static let pressedOpacity: Double = 0.86
+        package static let hoverDuration: TimeInterval = 0.12
+        package static let pressDuration: TimeInterval = 0.10
+
+        /// Reduce Motion 下不做几何缩放，只保留亮度/不透明度反馈。
+        package static func hoverScale(reduceMotion: Bool) -> CGFloat {
+            reduceMotion ? 1 : hoverScale
+        }
+
+        package static func pressedScale(_ scale: CGFloat = pressedScale, reduceMotion: Bool) -> CGFloat {
+            reduceMotion ? 1 : scale
+        }
     }
 }

--- a/Tests/VibelslandFreeCoreTests/IslandMotionFeedbackTests.swift
+++ b/Tests/VibelslandFreeCoreTests/IslandMotionFeedbackTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import VibelslandFreeCore
+
+@Suite
+struct IslandMotionFeedbackTests {
+    @Test func testEasedProgressEndpointsAndClamping() {
+        for expanded in [true, false] {
+            XCTAssertEqual(IslandMotionPolicy.WindowTransition.easedProgress(0, expanded: expanded), 0, "Easing starts at 0")
+            XCTAssertEqual(IslandMotionPolicy.WindowTransition.easedProgress(1, expanded: expanded), 1, "Easing ends at 1")
+            XCTAssertEqual(IslandMotionPolicy.WindowTransition.easedProgress(-0.5, expanded: expanded), 0, "Progress clamps below 0")
+            XCTAssertEqual(IslandMotionPolicy.WindowTransition.easedProgress(1.5, expanded: expanded), 1, "Progress clamps above 1")
+        }
+    }
+
+    @Test func testEasedProgressIsMonotonic() {
+        for expanded in [true, false] {
+            var previous = -0.001
+            for step in 0...20 {
+                let value = IslandMotionPolicy.WindowTransition.easedProgress(Double(step) / 20, expanded: expanded)
+                XCTAssertTrue(value >= previous, "Easing must be monotonic (expanded=\(expanded), step=\(step))")
+                previous = value
+            }
+        }
+    }
+
+    @Test func testExpansionEasingAttacksFasterThanCollapse() {
+        // 展开用 ease-out-cubic：前段进度领先，产生「跟手」的快速响应。
+        let expansionEarly = IslandMotionPolicy.WindowTransition.easedProgress(0.25, expanded: true)
+        let collapseEarly = IslandMotionPolicy.WindowTransition.easedProgress(0.25, expanded: false)
+        XCTAssertTrue(
+            expansionEarly > collapseEarly,
+            "Expansion easing leads at early progress (\(expansionEarly) vs \(collapseEarly))"
+        )
+        XCTAssertTrue(expansionEarly > 0.5, "Ease-out-cubic passes half distance by a quarter of the time")
+    }
+
+    @Test func testReduceMotionCollapsesDurationsToZero() {
+        XCTAssertEqual(
+            IslandMotionPolicy.WindowTransition.duration(expanded: true, reduceMotion: true),
+            0,
+            "Reduce Motion skips the expansion animation"
+        )
+        XCTAssertEqual(
+            IslandMotionPolicy.WindowTransition.duration(expanded: false, reduceMotion: true),
+            0,
+            "Reduce Motion skips the collapse animation"
+        )
+        XCTAssertEqual(
+            IslandMotionPolicy.WindowTransition.duration(expanded: true, reduceMotion: false),
+            IslandMotionPolicy.WindowTransition.expansionDuration,
+            "Normal mode keeps the expansion duration"
+        )
+        XCTAssertEqual(
+            IslandMotionPolicy.ContentTransition.crossfadeDuration(reduceMotion: true),
+            0,
+            "Reduce Motion skips the content crossfade"
+        )
+    }
+
+    @Test func testInteractionFeedbackConstantsAreSane() {
+        let feedback = IslandMotionPolicy.InteractionFeedback.self
+        XCTAssertTrue(feedback.pressedScale < 1, "Pressed state shrinks slightly")
+        XCTAssertTrue(feedback.cardPressedScale < 1, "Card pressed state shrinks slightly")
+        XCTAssertTrue(feedback.hoverScale > 1, "Hover state grows slightly")
+        XCTAssertTrue(feedback.hoverScale < 1.05, "Hover growth stays subtle")
+        XCTAssertTrue(feedback.pressedScale > 0.9, "Pressed shrink stays subtle")
+
+        XCTAssertEqual(feedback.hoverScale(reduceMotion: true), 1, "Reduce Motion removes hover scaling")
+        XCTAssertEqual(feedback.pressedScale(reduceMotion: true), 1, "Reduce Motion removes press scaling")
+        XCTAssertEqual(
+            feedback.pressedScale(reduceMotion: false),
+            feedback.pressedScale,
+            "Normal mode keeps the press scale"
+        )
+    }
+
+    @Test func testContentDepthScalesStayNearIdentity() {
+        let content = IslandMotionPolicy.ContentTransition.self
+        XCTAssertTrue(content.expandedLayerInitialScale < 1, "Expanded layer grows in from slightly below 1")
+        XCTAssertTrue(content.expandedLayerInitialScale > 0.95, "Depth scale stays subtle")
+        XCTAssertTrue(content.compactLayerLiftedScale > 1, "Compact layer lifts slightly past 1")
+        XCTAssertTrue(content.compactLayerLiftedScale < 1.06, "Lift scale stays subtle")
+    }
+}


### PR DESCRIPTION
## 概要

浮岛动效与交互反馈的整体打磨，三个层面：

### 动效
- **窗口帧动画**：固定 60Hz Timer → `CADisplayLink`（ProMotion 显示器满 120Hz），展开改用 ease-out-cubic（t=0.25 时已走过 57.8% 距离，跟手感）而收起保留 smoothstep 的温和对称；缓动曲线收敛进 `IslandMotionPolicy` 可单测。
- **内容过渡纵深**：展开层从 0.98 缩放生长到位、收起层轻微上浮到 1.03，交叉淡化读作「形变」而非「替换」。
- **审批卡片弹簧**：新审批到达、解决、摘要/队列/详情切换都有轻弹簧进出场。

### 交互反馈（此前完全没有悬停反馈）
- 所有可点元素：悬停轻微上浮 + 提亮 + **小手光标**；按压整体收缩。
- 关键修正：胶囊按钮的视觉层原来挂在 Button 外层，ButtonStyle 只能缩放文字——已把视觉层移进 label，按压反馈作用于整个胶囊。
- 紧凑药丸悬停上浮，明示可点击展开。

### 无障碍
- 系统「减弱动态效果」全链路生效：窗口/交叉淡化时长归零、悬停/按压缩放移除，保留亮度与不透明度提示。

## 验证

- 缓动数学独立进程 14 项全过（端点/夹取/单调性/展开前段领先/smoothstep 对称）。
- 新增 `IslandMotionFeedbackTests`（6 个用例，CI 执行）。
- 窗口自动化回归：展开/收起（真实驱动新 CADisplayLink 路径）、单审批 236pt、队列 288pt、idle 全过。
- 视觉快照脚本在截图步骤因本终端缺「屏幕录制」权限失败（环境限制）；其窗口几何断言（idle 隐藏、任务药丸尺寸）在此前步骤已通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)