### PR TITLE
fix: correct Japanese README checksum and harden release gates

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -82,7 +82,7 @@ shasum -a 256 -c Vibelsland-Free-0.1.0-macos.zip.sha256
 現在の SHA-256:
 
 ```text
-64c7c0a4eae81042bbc3896e24a07ab5d5573aeaafa846eada2e982f887ecf81
+b8ae6ea245d4720c1c9389c2ce95a582df9005866fda3522279058eb40b40af5
 ```
 
 インストール手順:

--- a/scripts/verify-docs-site.sh
+++ b/scripts/verify-docs-site.sh
@@ -842,7 +842,7 @@ for script_path, expected_values in {
             if value and value not in script_text and "release.json" not in script_text:
                 errors.append(f"{script_path.name} missing expected release metadata value: {value}")
 
-for path in [root / "README.md", root / "README.en.md"]:
+for path in [root / "README.md", root / "README.en.md", root / "README.ja.md"]:
     if path.exists():
         text = path.read_text(encoding="utf-8")
         for phrase in [release_label, release_archive_name, release_archive_hash, release_archive_url, release_checksum_url, "docs/release.json"]:
@@ -881,6 +881,7 @@ if verify_dist and checksum_path.exists():
             docs / "ja" / "download.html",
             root / "README.md",
             root / "README.en.md",
+            root / "README.ja.md",
         ]:
             if path.exists() and parts[0] not in path.read_text(encoding="utf-8"):
                 errors.append(f"Download page checksum does not match dist checksum: {display(path)}")

--- a/scripts/verify-release-readiness.sh
+++ b/scripts/verify-release-readiness.sh
@@ -115,6 +115,7 @@ if [[ "$RUN_AUTOMATION" == "1" ]]; then
         restore_public_release_assets
     fi
     VIBELSLAND_VERIFY_DIST=1 zsh "$ROOT/scripts/verify-docs-site.sh"
+    zsh "$ROOT/scripts/verify-cask.sh"
     zsh "$ROOT/scripts/verify-idle-window.sh"
     zsh "$ROOT/scripts/verify-single-instance.sh"
     zsh "$ROOT/scripts/verify-menu-settings.sh"


### PR DESCRIPTION
## 问题

系统排查发现：**README.ja.md 展示的 SHA-256（`64c7c0…`）与 release.json / 已发布资产 / 中英 README（`b8ae6e…`）不一致**——日语用户按文档核对摘要会对不上。

## 逃逸根因与加固

`verify-docs-site.sh` 的发布元数据一致性检查只覆盖 README.md 与 README.en.md，日语版漏检。本 PR：

1. 修正 README.ja.md 的哈希为 `b8ae6e…`。
2. 把 README.ja.md 纳入元数据一致性检查与 dist 模式校验清单（已做反向验证：故意破坏哈希后检查如期报 `README.ja.md missing release metadata value`）。
3. `verify-release-readiness.sh` 发布门禁加入 `verify-cask.sh`——cask 与 release.json 失同步时无法通过发布检查。

## 验证

- `verify-docs-site.sh` 通过（含新检查）。
- `verify-cask.sh` 通过。
- 排查同时确认：全量重编译零警告；本地可运行的验证脚本全部通过（`verify-menu-*`/`verify-system-overview-restore`/`verify-visual-snapshots` 因本终端 System Events 与屏幕录制权限属环境限制；批量运行时 `verify-runtime`/`verify-approval-response` 的偶发失败为进程清理竞态，单独运行均通过）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)