### PR TITLE
fix: smooth out the launch intro animation

### DIFF
--- a/Sources/VibelslandFree/AppDelegate.swift
+++ b/Sources/VibelslandFree/AppDelegate.swift
@@ -52,8 +52,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject, NSWi
         }
         applyGlobalHotKeys()
         installVerificationActionsIfNeeded()
-        showIsland(launchAnimated: true)
+        // 先完成 store 启动的同步 IO（装 Hook、起 bridge、健康检查），
+        // 开场动画在更安静的主线程上播放，减少掉帧。
         store.start()
+        showIsland(launchAnimated: true)
     }
 
     private func applyGlobalHotKeys() {
@@ -246,7 +248,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject, NSWi
             )
         }
         guard let islandWindow else { return }
-        guard launchAnimated, !hasPlayedLaunchIntro else {
+        // 跳过开场：系统减弱动态效果时；以及窗口自动化验证时（开场窗口会
+        // 干扰"空闲应隐藏"这类断言，且平白拖慢每个脚本 2.2 秒）。
+        let skipIntro = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+            || ProcessInfo.processInfo.environment["VIBELSLAND_SKIP_LAUNCH_INTRO"] == "1"
+        guard launchAnimated, !hasPlayedLaunchIntro, !skipIntro else {
+            hasPlayedLaunchIntro = true
             islandWindow.present(launchAnimated: false)
             return
         }

--- a/Sources/VibelslandFree/LaunchIntroWindow.swift
+++ b/Sources/VibelslandFree/LaunchIntroWindow.swift
@@ -1,4 +1,5 @@
 import AppKit
+import QuartzCore
 import VibelslandFreeCore
 
 @MainActor
@@ -6,19 +7,37 @@ final class LaunchIntroWindow: NSPanel {
     private weak var store: SessionStore?
     private let onComplete: () -> Void
     private let introView: BlackPillIntroView
-    private var timer: Timer?
+    private var displayLink: CADisplayLink?
     private var startedAt: CFTimeInterval = 0
     private var didPlaySound = false
     private var didComplete = false
     private let duration: CFTimeInterval = 2.20
 
+    /// 阴影 blur 18 + 偏移 5，四周留足边距，避免图层阴影被窗口裁剪。
+    private static let shadowMargin: CGFloat = 48
+
     init(finalFrame: NSRect, store: SessionStore, onComplete: @escaping () -> Void) {
         self.store = store
         self.onComplete = onComplete
-        let introFrame = Self.introFrame(for: finalFrame)
-        introView = BlackPillIntroView(
-            targetFrame: Self.localTargetFrame(finalFrame, in: introFrame)
+        let screenFrame = NSScreen.main?.visibleFrame ?? .init(x: 0, y: 0, width: 1440, height: 900)
+        // 目标药丸尺寸与旧实现一致的钳制规则。
+        let targetSize = CGSize(
+            width: min(max(finalFrame.width, 220), screenFrame.width - 64),
+            height: min(max(finalFrame.height, 42), 66)
         )
+        // 旧实现开整屏窗口每帧 CPU 重绘；现在窗口只包住药丸+阴影边距，
+        // backing store 缩小两个数量级。
+        let windowSize = CGSize(
+            width: targetSize.width + Self.shadowMargin * 2,
+            height: targetSize.height + Self.shadowMargin * 2
+        )
+        let introFrame = NSRect(
+            x: screenFrame.midX - windowSize.width / 2,
+            y: screenFrame.midY - windowSize.height / 2,
+            width: windowSize.width,
+            height: windowSize.height
+        )
+        introView = BlackPillIntroView(targetSize: targetSize)
 
         super.init(
             contentRect: introFrame,
@@ -43,25 +62,28 @@ final class LaunchIntroWindow: NSPanel {
     }
 
     func start() {
-        timer?.invalidate()
+        displayLink?.invalidate()
         didPlaySound = false
         didComplete = false
+        // 首次播放的波形生成与音频引擎初始化提前完成，动画中途不再卡顿。
+        if let store,
+           store.configurationStore.config.enableSounds,
+           !store.configurationStore.config.doNotDisturb {
+            RetroSoundPlayer.shared.prepare(.launch, theme: store.configurationStore.config.soundTheme)
+        }
         startedAt = CACurrentMediaTime()
         alphaValue = 1
         introView.progress = 0.001
         orderFrontRegardless()
         displayIfNeeded()
 
-        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.tick()
-            }
-        }
-        self.timer = timer
-        RunLoop.main.add(timer, forMode: .common)
+        // 跟随显示器刷新率、无并发跳板的直接回调，替代旧的 60Hz Timer + Task。
+        let link = introView.displayLink(target: self, selector: #selector(step(_:)))
+        link.add(to: .main, forMode: .common)
+        displayLink = link
     }
 
-    private func tick() {
+    @objc private func step(_ link: CADisplayLink) {
         guard !didComplete else { return }
         let elapsed = CACurrentMediaTime() - startedAt
         if elapsed >= 0.42, !didPlaySound {
@@ -79,8 +101,8 @@ final class LaunchIntroWindow: NSPanel {
     private func finish() {
         guard !didComplete else { return }
         didComplete = true
-        timer?.invalidate()
-        timer = nil
+        displayLink?.invalidate()
+        displayLink = nil
         orderOut(nil)
         onComplete()
     }
@@ -91,38 +113,55 @@ final class LaunchIntroWindow: NSPanel {
               !store.configurationStore.config.doNotDisturb else { return }
         RetroSoundPlayer.shared.play(.launch, theme: store.configurationStore.config.soundTheme)
     }
-
-    private static func introFrame(for finalFrame: NSRect) -> NSRect {
-        let screenFrame = NSScreen.main?.visibleFrame ?? .init(x: 0, y: 0, width: 1440, height: 900)
-        return screenFrame
-    }
-
-    private static func localTargetFrame(_ finalFrame: NSRect, in introFrame: NSRect) -> NSRect {
-        NSRect(
-            x: finalFrame.minX - introFrame.minX,
-            y: finalFrame.minY - introFrame.minY,
-            width: finalFrame.width,
-            height: finalFrame.height
-        )
-    }
 }
 
+/// 药丸开场：GPU 合成的 Core Animation 图层，替代旧的整屏 CPU draw(_:)。
+/// 阴影由带 shadowPath 的容器层渲染，渐变在子层内圆角裁剪，每帧只改
+/// 图层几何属性（禁用隐式动画），不再触发位图重绘。
 private final class BlackPillIntroView: NSView {
     var progress: CGFloat = 0 {
         didSet {
-            needsDisplay = true
+            render()
         }
     }
 
-    private let targetFrame: NSRect
+    private let targetSize: CGSize
+    private let pillContainer = CALayer()
+    private let gradientLayer = CAGradientLayer()
+    private let highlightLayer = CAShapeLayer()
 
     override var isOpaque: Bool { false }
 
-    init(targetFrame: NSRect) {
-        self.targetFrame = targetFrame
+    init(targetSize: CGSize) {
+        self.targetSize = targetSize
         super.init(frame: .zero)
         wantsLayer = true
         layer?.backgroundColor = NSColor.clear.cgColor
+
+        pillContainer.shadowColor = NSColor.black.cgColor
+        pillContainer.shadowRadius = 18
+        pillContainer.shadowOffset = CGSize(width: 0, height: -5)
+        pillContainer.shadowOpacity = 0
+
+        // 与旧 NSGradient(angle: -90) 相同：颜色从上往下。
+        gradientLayer.colors = [
+            NSColor(calibratedRed: 0.015, green: 0.017, blue: 0.020, alpha: 1).cgColor,
+            NSColor(calibratedRed: 0.065, green: 0.070, blue: 0.078, alpha: 1).cgColor,
+            NSColor(calibratedRed: 0.010, green: 0.012, blue: 0.014, alpha: 1).cgColor,
+        ]
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 1)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 0)
+        gradientLayer.masksToBounds = true
+
+        highlightLayer.fillColor = nil
+        highlightLayer.strokeColor = NSColor.white.cgColor
+        highlightLayer.lineWidth = 2.4
+        highlightLayer.lineCap = .round
+        highlightLayer.opacity = 0
+
+        pillContainer.addSublayer(gradientLayer)
+        gradientLayer.addSublayer(highlightLayer)
+        layer?.addSublayer(pillContainer)
     }
 
     @available(*, unavailable)
@@ -130,62 +169,57 @@ private final class BlackPillIntroView: NSView {
         nil
     }
 
-    override func draw(_ dirtyRect: NSRect) {
-        guard let context = NSGraphicsContext.current?.cgContext else { return }
-
+    private func render() {
         let p = min(max(progress, 0), 1)
         let grow = easeInOutCubic(min(p / 0.72, 1))
         let fade = p > 0.88 ? 1 - smoothStep(min(max((p - 0.88) / 0.12, 0), 1)) : 1
         let alpha = max(0, fade)
-        guard alpha > 0 else { return }
 
         let startDiameter: CGFloat = 8
-        let targetWidth = min(max(targetFrame.width, 220), bounds.width - 64)
-        let targetHeight = min(max(targetFrame.height, 42), 66)
-        let width = startDiameter + (targetWidth - startDiameter) * grow
-        let height = startDiameter + (targetHeight - startDiameter) * grow
-        let center = CGPoint(x: bounds.midX, y: bounds.midY)
+        let width = startDiameter + (targetSize.width - startDiameter) * grow
+        let height = startDiameter + (targetSize.height - startDiameter) * grow
         let rect = CGRect(
-            x: center.x - width / 2,
-            y: center.y - height / 2,
+            x: bounds.midX - width / 2,
+            y: bounds.midY - height / 2,
             width: width,
             height: height
         )
 
-        context.saveGState()
-        context.setAlpha(alpha)
-        let shadow = NSShadow()
-        shadow.shadowColor = NSColor.black.withAlphaComponent(0.28 * alpha)
-        shadow.shadowBlurRadius = 18
-        shadow.shadowOffset = NSSize(width: 0, height: -5)
-        shadow.set()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
 
-        let path = NSBezierPath(roundedRect: rect, xRadius: height / 2, yRadius: height / 2)
-        pillGradient.draw(in: path, angle: -90)
+        pillContainer.frame = rect
+        pillContainer.shadowOpacity = Float(0.28 * alpha)
+        pillContainer.shadowPath = CGPath(
+            roundedRect: CGRect(origin: .zero, size: rect.size),
+            cornerWidth: height / 2,
+            cornerHeight: height / 2,
+            transform: nil
+        )
+        pillContainer.opacity = Float(alpha)
+
+        gradientLayer.frame = CGRect(origin: .zero, size: rect.size)
+        gradientLayer.cornerRadius = height / 2
 
         if grow > 0.34 {
-            let highlightAlpha = min((grow - 0.34) / 0.34, 1) * 0.18 * alpha
-            let highlightRect = rect.insetBy(dx: rect.width * 0.18, dy: rect.height * 0.28)
-            let highlight = NSBezierPath()
-            highlight.move(to: CGPoint(x: highlightRect.minX, y: highlightRect.midY + 2))
-            highlight.curve(
+            let highlightAlpha = min((grow - 0.34) / 0.34, 1) * 0.18
+            let highlightRect = CGRect(origin: .zero, size: rect.size)
+                .insetBy(dx: rect.width * 0.18, dy: rect.height * 0.28)
+            let path = CGMutablePath()
+            path.move(to: CGPoint(x: highlightRect.minX, y: highlightRect.midY + 2))
+            path.addCurve(
                 to: CGPoint(x: highlightRect.maxX, y: highlightRect.midY + 2),
-                controlPoint1: CGPoint(x: highlightRect.minX + highlightRect.width * 0.34, y: highlightRect.maxY),
-                controlPoint2: CGPoint(x: highlightRect.minX + highlightRect.width * 0.64, y: highlightRect.minY)
+                control1: CGPoint(x: highlightRect.minX + highlightRect.width * 0.34, y: highlightRect.maxY),
+                control2: CGPoint(x: highlightRect.minX + highlightRect.width * 0.64, y: highlightRect.minY)
             )
-            NSColor.white.withAlphaComponent(highlightAlpha).setStroke()
-            highlight.lineWidth = 2.4
-            highlight.stroke()
+            highlightLayer.frame = CGRect(origin: .zero, size: rect.size)
+            highlightLayer.path = path
+            highlightLayer.opacity = Float(highlightAlpha)
+        } else {
+            highlightLayer.opacity = 0
         }
-        context.restoreGState()
-    }
 
-    private var pillGradient: NSGradient {
-        NSGradient(colors: [
-            NSColor(calibratedRed: 0.015, green: 0.017, blue: 0.020, alpha: 1),
-            NSColor(calibratedRed: 0.065, green: 0.070, blue: 0.078, alpha: 1),
-            NSColor(calibratedRed: 0.010, green: 0.012, blue: 0.014, alpha: 1)
-        ]) ?? NSGradient(starting: .black, ending: .darkGray)!
+        CATransaction.commit()
     }
 
     private func easeInOutCubic(_ value: CGFloat) -> CGFloat {

--- a/Sources/VibelslandFree/RetroSoundPlayer.swift
+++ b/Sources/VibelslandFree/RetroSoundPlayer.swift
@@ -19,12 +19,39 @@ final class RetroSoundPlayer {
     private var players: [AVAudioPlayer] = []
     private var generatedDataCache: [SoundCacheKey: Data] = [:]
     private var systemSoundCache: [RetroSoundKind: NSSound] = [:]
+    private var preparedPlayers: [SoundCacheKey: AVAudioPlayer] = [:]
 
     private init() {}
+
+    /// 预热：提前生成波形并让播放器完成缓冲，避免首次播放时的
+    /// 音频引擎初始化卡顿（启动动画中途播声音会掉帧就是这个原因）。
+    func prepare(_ kind: RetroSoundKind, theme: SoundTheme = .soft) {
+        if theme == .system {
+            if systemSoundCache[kind] == nil, let sound = NSSound(named: kind.systemSoundName) {
+                systemSoundCache[kind] = sound
+            }
+            return
+        }
+        let key = SoundCacheKey(kind: kind, theme: theme.rawValue)
+        guard preparedPlayers[key] == nil else { return }
+        let data = generatedData(for: kind, theme: theme)
+        guard let player = try? AVAudioPlayer(data: data) else { return }
+        player.volume = kind.volume(for: theme)
+        player.prepareToPlay()
+        preparedPlayers[key] = player
+    }
 
     func play(_ kind: RetroSoundKind, theme: SoundTheme = .soft) {
         if theme == .system {
             playSystemSound(kind)
+            return
+        }
+
+        let key = SoundCacheKey(kind: kind, theme: theme.rawValue)
+        if let prepared = preparedPlayers.removeValue(forKey: key) {
+            players.removeAll { !$0.isPlaying }
+            players.append(prepared)
+            prepared.play()
             return
         }
 

--- a/scripts/verify-support.sh
+++ b/scripts/verify-support.sh
@@ -1,5 +1,9 @@
 #!/bin/zsh
 
+# 验证运行统一跳过启动开场动画：开场窗口会干扰"空闲应隐藏"等窗口断言，
+# 且平白拖慢每个脚本约 2.2 秒。所有窗口脚本都 source 本文件，子进程继承此环境。
+export VIBELSLAND_SKIP_LAUNCH_INTRO=1
+
 vibelsland_log_path() {
     print "$1/Library/Logs/VibelslandFree/app.log"
 }


### PR DESCRIPTION
## 问题

用户反馈应用刚打开时的动态效果不流畅。

## 四个叠加根因与修复

| 根因 | 修复 |
|---|---|
| 60Hz 固定 Timer，且每帧经 `Task { @MainActor }` 并发跳板 | `CADisplayLink` 直接回调，跟随显示器刷新率（ProMotion 满 120Hz） |
| 整屏 backing store 每帧 CPU 重绘（含 blur 18 的 NSShadow） | GPU 合成的 CA 图层（shadowPath 容器 + 圆角裁剪渐变），窗口从全屏缩到药丸+阴影边距 |
| 0.42s 处首次播声音时现场生成波形+初始化音频引擎 | `RetroSoundPlayer.prepare()` 预热，动画开始前完成 |
| `store.start()` 的同步 IO（装 Hook/起 socket/健康检查）与动画并发 | 启动 IO 先行，动画在安静的主线程上播放 |

视觉设计不变（时长 2.2s、生长/淡出相位、缓动曲线、0.42s 音效点）。另：Reduce Motion 跳过开场；自动化验证经 `verify-support.sh` 统一跳过开场（旧全屏开场窗口恰好落在所有窗口检查的尺寸边界外而"隐身"，缩小后会被 `verify-single-instance` 的空闲隐藏断言误抓——跳过装饰性开场是诚实修法，且每个脚本省 2.2 秒）。

## 验证

- 真实启动：t≈0.9s 开场窗口以 316×139 药丸尺寸在播 → t≈3.9s 结束且空闲正确隐藏。
- 回归：single-instance / idle / approval / expand-collapse 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)