### PR TITLE
feat: show the island briefly on every launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,4 +30,5 @@
 
 ## Unreleased
 
+- The island now shows itself (idle-mini) for about eight seconds on every launch so you can tell the app started, then hides as usual when idle.
 - Global hotkeys are now customizable per action (record any key combo in settings), and gain two new actions with bare-key defaults: Space approves the pending approval and Backspace declines it. Bare keys register only while an approval is pending and release immediately after, so normal typing is never captured.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@
 - Added settings, hook installation, runtime health checks, single-instance protection, and restart recovery.
 - Published the GitHub Pages documentation site, install notes, privacy note, checksum metadata, and release packaging scripts.
 
-## Unreleased
-
-- Global hotkeys are now customizable per action (record any key combo in settings), and gain two new actions with bare-key defaults: Space approves the pending approval and Backspace declines it. Bare keys register only while an approval is pending and release immediately after, so normal typing is never captured.
-
 ## 0.2.0 - 2026-07-04
 
 - Smoothed the launch intro: display-link driven GPU layers replace the per-frame CPU redraw, the launch sound is prewarmed, and startup IO completes before the animation begins. Reduce Motion skips the intro.
@@ -31,3 +27,7 @@
 - Added GitHub Actions checks for Swift build and test-target discovery.
 - Added maintainer release gate improvements and clearer ad-hoc signing documentation.
 - Improved Codex Desktop live connection startup from Finder-launched macOS app environments.
+
+## Unreleased
+
+- Global hotkeys are now customizable per action (record any key combo in settings), and gain two new actions with bare-key defaults: Space approves the pending approval and Backspace declines it. Bare keys register only while an approval is pending and release immediately after, so normal typing is never captured.

--- a/Sources/VibelslandFree/IslandWindow.swift
+++ b/Sources/VibelslandFree/IslandWindow.swift
@@ -164,7 +164,8 @@ final class IslandWindow: NSPanel {
                     isExpanded: isExpanded,
                     isApprovalDetailVisible: content.2,
                     maxVisibleSessions: config.maxVisibleSessions,
-                    position: config.islandPosition
+                    position: config.islandPosition,
+                    isLaunchPresenceActive: self?.store?.isLaunchPresenceActive ?? false
                 )
                 self?.applyLayout(signature, animated: true)
             }
@@ -323,6 +324,10 @@ final class IslandWindow: NSPanel {
 
     private func shouldHideIdlePresentation(expanded: Bool) -> Bool {
         guard let store, !expanded else { return false }
+        // 启动亮相期内空闲也不隐藏，让用户看到应用已启动。
+        if store.isLaunchPresenceActive {
+            return false
+        }
         return IslandPresentationPolicy.isIdleMiniPresentation(
             sessions: store.sessions,
             isExpanded: false

--- a/Sources/VibelslandFree/SessionStore.swift
+++ b/Sources/VibelslandFree/SessionStore.swift
@@ -36,6 +36,12 @@ final class SessionStore: ObservableObject {
     @Published var healthChecks: [HealthCheckItem] = []
     @Published var sessionVisibilityRefreshToken = 0
     @Published var updateCheckState: UpdateCheckState = .idle
+    /// 启动亮相截止时间：此前即使空闲也不隐藏浮岛，让用户看到应用已启动。
+    var launchPresenceUntil: Date?
+
+    var isLaunchPresenceActive: Bool {
+        IslandPresentationPolicy.isLaunchPresenceActive(until: launchPresenceUntil)
+    }
 
     let configurationStore: AppConfigurationStore
 
@@ -267,7 +273,28 @@ final class SessionStore: ObservableObject {
         if configurationStore.config.autoCheckUpdates {
             checkForUpdates()
         }
+        beginLaunchPresenceIfNeeded()
         startVisibilityTimer()
+    }
+
+    /// 启动亮相：宽限期内空闲也显示 idle-mini；到期后 bump 可见性 token
+    /// 让布局签名变化、窗口按常规策略隐藏。验证运行沿用跳过开场的环境变量。
+    private func beginLaunchPresenceIfNeeded() {
+        guard ProcessInfo.processInfo.environment["VIBELSLAND_SKIP_LAUNCH_INTRO"] != "1" else { return }
+        let duration = IslandPresentationPolicy.launchPresenceDuration
+        launchPresenceUntil = Date().addingTimeInterval(duration)
+        let timer = Timer(timeInterval: duration + 0.3, repeats: false) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.launchPresenceUntil = nil
+                // 直接 bump token 触发布局签名重算（refreshVisibleSessionAging
+                // 在无会话时会提前返回，不能依赖它）。
+                self.sessionVisibilityRefreshToken = self.sessionVisibilityRefreshToken == Int.max
+                    ? 0
+                    : self.sessionVisibilityRefreshToken + 1
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
     }
 
     func installSelectedHooks() {

--- a/Sources/VibelslandFreeCore/IslandLayoutSignature.swift
+++ b/Sources/VibelslandFreeCore/IslandLayoutSignature.swift
@@ -9,6 +9,7 @@ package struct IslandLayoutSignature: Equatable {
     package var pendingApprovalCount: Int
     package var visibleSessionCount: Int
     package var isShowingApprovalDetail: Bool
+    package var isLaunchPresenceActive: Bool
 
     package init(
         sessions: [AgentSession],
@@ -17,6 +18,7 @@ package struct IslandLayoutSignature: Equatable {
         isApprovalDetailVisible: Bool,
         maxVisibleSessions: Int,
         position: IslandPosition,
+        isLaunchPresenceActive: Bool = false,
         now: Date = Date()
     ) {
         let approvalQueue = ApprovalQueuePolicy.queue(in: sessions)
@@ -39,5 +41,6 @@ package struct IslandLayoutSignature: Equatable {
             now: now
         ).count
         self.isShowingApprovalDetail = isApprovalDetailVisible && pendingApproval != nil
+        self.isLaunchPresenceActive = isLaunchPresenceActive
     }
 }

--- a/Sources/VibelslandFreeCore/IslandPresentationPolicy.swift
+++ b/Sources/VibelslandFreeCore/IslandPresentationPolicy.swift
@@ -11,6 +11,15 @@ package enum IslandPresentationPolicy {
     package static let idleMiniDiameter: CGFloat = 34
     package static let compactTaskSize = CGSize(width: 244, height: 42)
 
+    /// 启动亮相：应用启动后的一段时间内即使空闲也显示浮岛本体（idle-mini），
+    /// 让用户确认应用已经正确启动；到期后按常规策略隐藏。
+    package static let launchPresenceDuration: TimeInterval = 8
+
+    package static func isLaunchPresenceActive(until deadline: Date?, now: Date = Date()) -> Bool {
+        guard let deadline else { return false }
+        return now < deadline
+    }
+
     package static func mode(
         sessions: [AgentSession],
         isExpanded: Bool,


### PR DESCRIPTION
## 概要

此前空闲冷启动时浮岛完全隐藏，用户无法确认应用是否启动成功。现在**每次启动后浮岛本体（idle-mini）亮相约 8 秒**，随后按常规空闲策略隐藏。

## 实现

- `launchPresenceUntil` 截止时间：窗口隐藏判定与布局签名共同参照；到期直接 bump 可见性 token 触发签名变化重新布局（`refreshVisibleSessionAging` 在零会话时提前返回，不能依赖——首测就踩到了这个坑并修复）。
- 验证运行沿用跳过开场的同一环境门控，空闲隐藏类断言不受影响。

## 验证

- 真实冷启动：t≈4s 屏幕上有 34×34 idle-mini，t≈11s 正确隐藏。
- idle-window / single-instance 回归通过。

堆叠链 2/3，base 为 feat/custom-hotkeys。

🤖 Generated with [Claude Code](https://claude.com/claude-code)